### PR TITLE
Fix - NextAuth URL fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_AUTH_URL="http://localhost:3000"
+NEXTAUTH_URL="http://localhost:3000"
 # if empty in PRODUCTION, will fail.
 NEXTAUTH_SECRET=""
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -2,7 +2,6 @@ import NextAuth from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
 import { createAppClient, viemConnector } from "@farcaster/auth-client"
 import { NextApiRequest, NextApiResponse } from "next"
-import { domainFromNextUrl } from '@/utils/farcaster'
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default (req: NextApiRequest, res: NextApiResponse) =>
@@ -44,15 +43,19 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
             ethereum: viemConnector(),
           })
 
+          if (!process.env.NEXTAUTH_URL) {
+          }
+
           const verifyResponse = await appClient.verifySignInMessage({
             message: credentials?.message as string,
             signature: credentials?.signature as `0x${string}`,
-            domain: domainFromNextUrl(),
+            domain: new URL(process.env.NEXTAUTH_URL || 'NEXTAUTH_URL must be set.').host,
             nonce: csrfToken,
           })
           const { success, fid } = verifyResponse
 
           if (!success) {
+            console.error('Failed to verify sign in with Farcaster. Check domain in nextauth config and in utils/farcaster.ts')
             return null
           }
 

--- a/utils/farcaster.ts
+++ b/utils/farcaster.ts
@@ -13,8 +13,19 @@ declare interface AuthKitConfig {
 }
 
 export const domainFromNextUrl = () => {
-  const url = process.env.NEXT_PUBLIC_AUTH_URL || 'http://localhost:3000'
-  return new URL(url).host
+  if (process.env.NEXTAUTH_URL) {
+    return new URL(process.env.NEXTAUTH_URL).host
+  }
+
+  return window.location.host
+}
+
+export const getAppUri = () => {
+  if (process.env.NEXTAUTH_URL) {
+    return new URL(process.env.NEXTAUTH_URL).href
+  }
+
+  return window.location.href
 }
 
 export const authKitConfig: AuthKitConfig = {
@@ -24,5 +35,5 @@ export const authKitConfig: AuthKitConfig = {
   domain: domainFromNextUrl(),
 
   // extra slash at end is important.
-  siweUri: (process.env.NEXT_PUBLIC_AUTH_URL || 'http://localhost:3000') + '/'
+  siweUri: getAppUri()
 }


### PR DESCRIPTION
With NextAuth, `NEXTAUTH_URL` will still be required. 

To prevent having two identical env vars 
- one public `NEXTAUTH_PUBLIC_URL` for the client side to access
- the one that NextAuth requires `NEXTAUTH_URL`

I improved the checks for `NEXTAUTH_URL` and added fallback logic ( using `window.location` for client side that does not have access to `NEXTAUTH_URL`
