### PR TITLE
Optimize SEO metadata and crawler coverage

### DIFF
--- a/components/farcaster/FarcasterFrameHead.tsx
+++ b/components/farcaster/FarcasterFrameHead.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Head from 'next/head'
+import { DEFAULT_OG_IMAGE, SITE_URL, absoluteUrl } from '@/lib/seo'
 
 type Props = {
   imgUrl: string
@@ -14,7 +15,7 @@ export const FarcasterFrameHead: React.FC<Props> = ({
   children,
   frameImageAspectRatio
 }) => {
-    const imageUrl = imgUrl || "https://www.intori.co/og/og-default.jpg"
+    const imageUrl = absoluteUrl(imgUrl || DEFAULT_OG_IMAGE)
     return (
       <Head>
         <meta charSet="utf-8"/>
@@ -22,8 +23,15 @@ export const FarcasterFrameHead: React.FC<Props> = ({
         <title>intori - Made for you. Within minutes.</title>
         <meta name="description" content={description} />
 
-        <meta property="og:title" content="intori - Made for you. Within minutes." />
-        <meta property="og:image" content={imageUrl} />
+        <meta property="og:title" content="intori - Made for you. Within minutes." key="og-title" />
+        <meta property="og:description" content={description} key="og-description" />
+        <meta property="og:url" content={SITE_URL} key="og-url" />
+        <meta property="og:image" content={imageUrl} key="og-image" />
+        <meta property="og:image:secure_url" content={imageUrl} key="og-image-secure-url" />
+        <meta name="twitter:card" content="summary_large_image" key="twitter-card" />
+        <meta name="twitter:title" content="intori - Made for you. Within minutes." key="twitter-title" />
+        <meta name="twitter:description" content={description} key="twitter-description" />
+        <meta name="twitter:image" content={imageUrl} key="twitter-image" />
 
         <meta property="fc:frame" content="vNext" />
         <meta property="fc:frame:image" content={imageUrl} />

--- a/layouts/App/index.tsx
+++ b/layouts/App/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import Link from 'next/link'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useSession, signOut } from "next-auth/react"
 import Image from 'next/image'
@@ -57,6 +58,9 @@ export const AppLayout: React.FC<Props> = ({ children }) => {
   if (session?.status !== 'authenticated') {
     return (
       <div className={styles.appLayout}>
+        <Head>
+          <meta name="robots" content="noindex,nofollow" key="robots" />
+        </Head>
         <header className={styles.header}>
           <div className={styles.headerLeft}>
             <Image src="/intorilogomark.svg" alt="Intori" width={26} height={35} />
@@ -74,6 +78,9 @@ export const AppLayout: React.FC<Props> = ({ children }) => {
 
   return (
     <div className={styles.appLayout}>
+      <Head>
+        <meta name="robots" content="noindex,nofollow" key="robots" />
+      </Head>
       <header className={styles.header}>
         <div className={styles.headerLeft}>
           <Image src="/intorilogomark.svg" alt="Intori" width={26} height={35} />
@@ -130,4 +137,3 @@ export const AppLayout: React.FC<Props> = ({ children }) => {
     </div>
   )
 }
-

--- a/lib/seo.tsx
+++ b/lib/seo.tsx
@@ -1,0 +1,73 @@
+import Head from 'next/head'
+
+export const SITE_URL = 'https://www.intori.co'
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/og/og-default.jpg`
+export const DEFAULT_TITLE = 'intori - Made for you. Within minutes.'
+export const DEFAULT_DESCRIPTION =
+  'Choose where to start, answer a few quick questions, and intori shapes personalized recommendations, plans, drafts, and more around you.'
+export const DEFAULT_SOCIAL_DESCRIPTION =
+  'Choose where to start, answer quick questions, and intori gives you a more personal starting point.'
+
+type SeoHeadProps = {
+  title?: string
+  description?: string
+  canonicalPath?: string
+  ogTitle?: string
+  ogDescription?: string
+  ogImage?: string
+  ogImageWidth?: string
+  ogImageHeight?: string
+  ogImageAlt?: string
+  ogType?: 'website' | 'article'
+  robots?: string
+}
+
+export function absoluteUrl(pathOrUrl: string) {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+    return pathOrUrl
+  }
+
+  return `${SITE_URL}${pathOrUrl.startsWith('/') ? '' : '/'}${pathOrUrl}`
+}
+
+export function SeoHead({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  canonicalPath,
+  ogTitle = title,
+  ogDescription = description,
+  ogImage = DEFAULT_OG_IMAGE,
+  ogImageWidth = '1800',
+  ogImageHeight = '945',
+  ogImageAlt = 'intori app preview',
+  ogType = 'website',
+  robots = 'index,follow',
+}: SeoHeadProps) {
+  const canonicalUrl = canonicalPath ? absoluteUrl(canonicalPath) : undefined
+  const imageUrl = absoluteUrl(ogImage)
+
+  return (
+    <Head>
+      <title key="title">{title}</title>
+      <meta name="description" content={description} key="description" />
+      <meta name="robots" content={robots} key="robots" />
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} key="canonical" />}
+      <meta property="og:title" content={ogTitle} key="og-title" />
+      <meta property="og:description" content={ogDescription} key="og-description" />
+      {canonicalUrl && <meta property="og:url" content={canonicalUrl} key="og-url" />}
+      <meta property="og:type" content={ogType} key="og-type" />
+      <meta property="og:site_name" content="intori" key="og-site-name" />
+      <meta property="og:locale" content="en_US" key="og-locale" />
+      <meta property="og:image" content={imageUrl} key="og-image" />
+      <meta property="og:image:secure_url" content={imageUrl} key="og-image-secure-url" />
+      <meta property="og:image:width" content={ogImageWidth} key="og-image-width" />
+      <meta property="og:image:height" content={ogImageHeight} key="og-image-height" />
+      <meta property="og:image:alt" content={ogImageAlt} key="og-image-alt" />
+      <meta name="twitter:card" content="summary_large_image" key="twitter-card" />
+      <meta name="twitter:title" content={ogTitle} key="twitter-title" />
+      <meta name="twitter:description" content={ogDescription} key="twitter-description" />
+      <meta name="twitter:image" content={imageUrl} key="twitter-image" />
+      <meta name="twitter:image:alt" content={ogImageAlt} key="twitter-image-alt" />
+    </Head>
+  )
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { Fragment } from 'react'
 import './global.css'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { SeoHead } from '@/lib/seo'
 
 Chart.register(CategoryScale)
 
@@ -29,26 +30,10 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width, viewport-fit=cover"
         />
-        <title>intori — Made for you. Within minutes.</title>
-        <meta name="description" content="Choose where to start, answer a few quick questions, and intori shapes personalized recommendations, plans, drafts, and more around you."/>
-        <link rel="canonical" href="https://www.intori.co/" />
         <meta name="keywords" content="intori, World, personalization, music ideas, game day ideas, time planning, drafts"/>
         <meta name="author" content="Tuum Tech"/>
-        <meta property="og:title" content="intori — Made for you. Within minutes." />
-        <meta property="og:description" content="Choose where to start, answer quick questions, and intori gives you a more personal starting point." />
-        <meta property="og:url" content="https://www.intori.co/" />
-        <meta property="og:type" content="website"/>
-        <meta property="og:site_name" content="intori" />
-        <meta property="og:locale" content="en_US" />
-        <meta property="og:image" content="https://www.intori.co/og/og-default.jpg" key="og-image" />
-        <meta property="og:image:width" content="1800" key="og-image-width" />
-        <meta property="og:image:height" content="945" key="og-image-height" />
-        <meta property="og:image:alt" content="intori" key="og-image-alt" />
-        <meta name="twitter:card" content="summary_large_image" key="twitter-card" />
-        <meta name="twitter:title" content="intori — Made for you. Within minutes." key="twitter-title" />
-        <meta name="twitter:description" content="Choose where to start, answer quick questions, and intori gives you a more personal starting point." key="twitter-description" />
-        <meta name="twitter:image" content="https://www.intori.co/og/og-default.jpg" key="twitter-image" />
       </Head>
+      <SeoHead canonicalPath="/" />
       <SessionProvider session={session}>
         <QueryClientProvider client={queryClient}>
           <ToastContainer position="top-right" />

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,25 +1,19 @@
 import type { NextPage } from "next"
-import Head from "next/head"
 
 import { MarketingFooter, MarketingHeader } from "@/components/MarketingChrome"
 import { FAQ } from "../lib/faq"
+import { SeoHead } from "@/lib/seo"
 import styles from "./index.module.css"
 
 const FaqPage: NextPage = () => {
   return (
     <>
-      <Head>
-        <title>FAQ - intori</title>
-        <meta
-          name="description"
-          content="Questions about intori, personalization, World, Credits, and continuing in your favorite AI tool."
-        />
-        <meta property="og:title" content="FAQ - intori" />
-        <meta
-          property="og:description"
-          content="Questions about intori, personalization, World, Credits, and continuing in your favorite AI tool."
-        />
-      </Head>
+      <SeoHead
+        title="FAQ - intori"
+        description="Questions about intori, personalization, World, Credits, and continuing in your favorite AI tool."
+        canonicalPath="/faq"
+        ogImageAlt="intori FAQ preview"
+      />
 
       <div className={styles.page}>
         <MarketingHeader />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,9 @@
 import type { GetServerSideProps } from "next";
-import Head from 'next/head'
 import Image from 'next/image'
 import { getSession } from "next-auth/react"
 import { Fragment, type CSSProperties } from 'react'
 import { MarketingFooter, MarketingHeader } from '@/components/MarketingChrome'
+import { SeoHead } from '@/lib/seo'
 
 import styles from './index.module.css'
 
@@ -199,13 +199,13 @@ function HowVisual({ type }: { type: string }) {
 export default function HomePage() {
   return (
     <>
-      <Head>
-        <title>intori — Made for you. Within minutes.</title>
-        <meta name="description" content="Answer a few quick questions and intori gives you a useful first pass for music, sports, planning, drafts, and more. No prompt writing." />
-        <meta property="og:title" content="intori — Made for you. Within minutes." />
-        <meta property="og:description" content="Answer a little. Get a useful first pass that already knows what matters to you." />
-        <meta property="og:image" content="https://www.intori.co/og/og-default.jpg" />
-      </Head>
+      <SeoHead
+        title="intori - Made for you. Within minutes."
+        description="Answer a few quick questions and intori gives you a useful first pass for music, sports, planning, drafts, and more. No prompt writing."
+        canonicalPath="/"
+        ogDescription="Answer a little. Get a useful first pass that already knows what matters to you."
+        ogImageAlt="intori preview with personalized app signals"
+      />
 
       <div className={styles.page}>
 

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -2,14 +2,13 @@ import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'ne
 import Head from 'next/head'
 import { MarketingFooter, MarketingHeader, WorldIcon } from '@/components/MarketingChrome'
 import { getAllSlugs, getPostBySlug, type Post } from '@/lib/news'
+import { SeoHead, SITE_URL, absoluteUrl } from '@/lib/seo'
 import styles from './news.module.css'
 
 const WORLD_APP_URL =
   'https://world.org/mini-app?app_id=app_263f86463869627f1183badc977e21a3'
 const FARCASTER_URL =
   'https://warpcast.com/~/frames/launch?domain=frame.intori.co'
-const SITE_URL = 'https://www.intori.co'
-const DEFAULT_OG_IMAGE = `${SITE_URL}/og/og-default.jpg`
 const LAUNCH_ARTICLE_SLUG = 'intori-now-live-on-world'
 const LAUNCH_OG_IMAGE = `${SITE_URL}/news/intori-world-01.png`
 
@@ -45,43 +44,29 @@ function formatDate(dateStr: string) {
   })
 }
 
-function toAbsoluteImageUrl(url: string) {
-  if (url.startsWith('http://') || url.startsWith('https://')) {
-    return url
-  }
-
-  return `${SITE_URL}${url.startsWith('/') ? '' : '/'}${url}`
-}
-
 export default function NewsPost({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   const isLaunchArticle = post.slug === LAUNCH_ARTICLE_SLUG
-  const canonicalUrl = `${SITE_URL}/news/${post.slug}`
   const pageTitle = `${post.title} — intori`
   const ogImage = isLaunchArticle
     ? LAUNCH_OG_IMAGE
-    : toAbsoluteImageUrl(post.heroImage || DEFAULT_OG_IMAGE)
+    : absoluteUrl(post.heroImage || '/og/og-default.jpg')
 
   return (
     <div className={styles.newsArticleWrapper}>
+      <SeoHead
+        title={pageTitle}
+        description={post.dek}
+        canonicalPath={`/news/${post.slug}`}
+        ogType="article"
+        ogImage={ogImage}
+        ogImageWidth="3200"
+        ogImageHeight="1800"
+        ogImageAlt={post.title}
+      />
       <Head>
-        <title>{pageTitle}</title>
-        <meta name="description" content={post.dek} />
-        <link rel="canonical" href={canonicalUrl} />
-        <meta property="og:title" content={pageTitle} />
-        <meta property="og:description" content={post.dek} />
-        <meta property="og:url" content={canonicalUrl} />
-        <meta property="og:type" content="article" />
-        <meta property="og:image" content={ogImage} key="og-image" />
-        <meta property="og:image:secure_url" content={ogImage} key="og-image-secure-url" />
-        {isLaunchArticle && <meta property="og:image:width" content="1200" key="og-image-width" />}
-        {isLaunchArticle && <meta property="og:image:height" content="675" key="og-image-height" />}
         <meta property="article:published_time" content={post.date} />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={pageTitle} />
-        <meta name="twitter:description" content={post.dek} />
-        <meta name="twitter:image" content={ogImage} key="twitter-image" />
       </Head>
 
       <div className={styles.page}>

--- a/pages/news/index.tsx
+++ b/pages/news/index.tsx
@@ -1,8 +1,8 @@
 import type { GetStaticProps, InferGetStaticPropsType } from 'next'
-import Head from 'next/head'
 import Link from 'next/link'
 import { MarketingFooter, MarketingHeader } from '@/components/MarketingChrome'
 import { getAllPosts, type PostMeta } from '@/lib/news'
+import { SeoHead } from '@/lib/seo'
 import styles from './news.module.css'
 
 type Props = {
@@ -28,35 +28,12 @@ export default function NewsIndex({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
-      <Head>
-        <title>News — intori</title>
-        <meta
-          name="description"
-          content="Official announcements and updates from intori."
-        />
-        <link rel="canonical" href="https://www.intori.co/news" />
-        <meta property="og:title" content="News — intori" />
-        <meta
-          property="og:description"
-          content="Official announcements and updates from intori."
-        />
-        <meta property="og:url" content="https://www.intori.co/news" />
-        <meta property="og:type" content="website" />
-        <meta
-          property="og:image"
-          content="https://www.intori.co/og/og-default.jpg"
-        />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="News — intori" />
-        <meta
-          name="twitter:description"
-          content="Official announcements and updates from intori."
-        />
-        <meta
-          name="twitter:image"
-          content="https://www.intori.co/og/og-default.jpg"
-        />
-      </Head>
+      <SeoHead
+        title="News - intori"
+        description="Official announcements and updates from intori."
+        canonicalPath="/news"
+        ogImageAlt="intori news preview"
+      />
 
       <div className={styles.page}>
         <MarketingHeader />

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,17 +1,16 @@
 import type { NextPage } from "next";
-import Head from 'next/head'
 import { LegalLayout } from '../layouts/Legal'
+import { SeoHead } from '@/lib/seo'
 
 const Privacy: NextPage = () => {
   return (
     <>
-      <Head>
-        <title>Privacy Policy — intori</title>
-        <meta
-          name="description"
-          content="How intori collects, uses, and protects information."
-        />
-      </Head>
+      <SeoHead
+        title="Privacy Policy - intori"
+        description="How intori collects, uses, and protects information."
+        canonicalPath="/privacy-policy"
+        ogImageAlt="intori privacy policy preview"
+      />
 
       <LegalLayout>
         <h1>intori Privacy Policy</h1>

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,79 @@
+import type { GetServerSideProps } from 'next'
+import { getAllPosts } from '@/lib/news'
+import { SITE_URL } from '@/lib/seo'
+
+const staticRoutes = [
+  { path: '/', priority: '1.0', changefreq: 'weekly' },
+  { path: '/news', priority: '0.8', changefreq: 'weekly' },
+  { path: '/faq', priority: '0.7', changefreq: 'monthly' },
+  { path: '/privacy-policy', priority: '0.3', changefreq: 'yearly' },
+  { path: '/terms-of-use', priority: '0.3', changefreq: 'yearly' },
+]
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function sitemapEntry({
+  path,
+  lastmod,
+  changefreq,
+  priority,
+}: {
+  path: string
+  lastmod: string
+  changefreq: string
+  priority: string
+}) {
+  return [
+    '  <url>',
+    `    <loc>${escapeXml(`${SITE_URL}${path}`)}</loc>`,
+    `    <lastmod>${lastmod}</lastmod>`,
+    `    <changefreq>${changefreq}</changefreq>`,
+    `    <priority>${priority}</priority>`,
+    '  </url>',
+  ].join('\n')
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const today = new Date().toISOString().slice(0, 10)
+  const posts = getAllPosts()
+  const entries = [
+    ...staticRoutes.map((route) =>
+      sitemapEntry({
+        ...route,
+        lastmod: today,
+      })
+    ),
+    ...posts.map((post) =>
+      sitemapEntry({
+        path: `/news/${post.slug}`,
+        lastmod: post.date,
+        changefreq: 'monthly',
+        priority: '0.7',
+      })
+    ),
+  ]
+
+  const sitemap = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    '</urlset>',
+  ].join('\n')
+
+  res.setHeader('Content-Type', 'application/xml')
+  res.write(sitemap)
+  res.end()
+
+  return { props: {} }
+}
+
+export default function Sitemap() {
+  return null
+}

--- a/pages/terms-of-use.tsx
+++ b/pages/terms-of-use.tsx
@@ -1,17 +1,16 @@
 import type { NextPage } from "next";
-import Head from 'next/head'
 import { LegalLayout } from '../layouts/Legal'
+import { SeoHead } from '@/lib/seo'
 
 const Terms: NextPage = () => {
   return (
     <>
-      <Head>
-        <title>Terms of Use — intori</title>
-        <meta
-          name="description"
-          content="Terms for using intori."
-        />
-      </Head>
+      <SeoHead
+        title="Terms of Use - intori"
+        description="Terms for using intori."
+        canonicalPath="/terms-of-use"
+        ogImageAlt="intori terms of use preview"
+      />
 
       <LegalLayout>
         <h1>intori Terms of Use</h1>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /dashboard/
+
+Sitemap: https://www.intori.co/sitemap.xml


### PR DESCRIPTION
## Summary
- centralize public SEO metadata in a shared SeoHead helper so page-specific canonicals and social tags replace defaults cleanly
- add route-specific canonicals, OG/Twitter image metadata, and alt text across home, FAQ, news, privacy, and terms pages
- add robots.txt and a dynamic sitemap.xml covering public marketing, legal, FAQ, and news routes
- mark dashboard/admin surfaces noindex,nofollow and improve Farcaster frame social metadata

## Verification
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm build
- locally rendered /, /faq, /news/introducing-scis, /robots.txt, and /sitemap.xml to confirm crawler-facing tags and sitemap output