### PR TITLE
Make web the primary path for V2 gate-open

### DIFF
--- a/components/MarketingChrome/index.tsx
+++ b/components/MarketingChrome/index.tsx
@@ -3,8 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 
 import styles from './styles.module.css'
-
-const WORLD_APP_URL = "https://world.org/mini-app?app_id=app_263f86463869627f1183badc977e21a3"
+import { APP_URL } from '@/lib/appLinks'
 
 export function WorldIcon({ size = 17 }: { size?: number }) {
   return (
@@ -36,13 +35,12 @@ export function MarketingHeader() {
             <Link href="/news" className={styles.navLink}>News</Link>
             <span className={styles.navLinkDisabled} aria-disabled="true">Developers</span>
             <a
-              href={WORLD_APP_URL}
+              href={APP_URL}
               className={styles.ctaPrimary}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <WorldIcon />
-              Open on World
+              Get started
             </a>
           </nav>
         </div>

--- a/components/signin/SigninHeader.tsx
+++ b/components/signin/SigninHeader.tsx
@@ -12,10 +12,10 @@ const SigninHeader: NextPage = () => {
       />
       <div className='self-stretch flex flex-col items-center justify-start gap-[12px]'>
         <div className='self-stretch relative font-semibold'>
-          Sign in to Intori with Farcaster
+          Sign in to the intori dashboard
         </div>
         <div className='w-full relative text-sm leading-[22px] font-light text-white-1 inline-block max-w-[300px]'>
-          Get paid for what you already do and earn from online activity.
+          Internal access for the intori team. To use intori, visit app.intori.co.
         </div>
       </div>
     </div>

--- a/lib/appLinks.ts
+++ b/lib/appLinks.ts
@@ -1,0 +1,13 @@
+// Shared destinations for "open the app" calls-to-action.
+//
+// V2 (gate-open, 2026-06): the web app is the PRIMARY entry point. The World App
+// mini-app is a secondary path; the Farcaster frame is legacy/test only.
+export const APP_URL = 'https://app.intori.co'
+
+export const WORLD_APP_URL =
+  'https://world.org/mini-app?app_id=app_263f86463869627f1183badc977e21a3'
+
+// Legacy Farcaster frame launcher — retained for reference, not surfaced as a
+// primary or secondary CTA on consumer marketing surfaces.
+export const FARCASTER_FRAME_URL =
+  'https://warpcast.com/~/frames/launch?domain=frame.intori.co'

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -9,7 +9,7 @@ export const FAQ: FaqItem[] = [
     question: "What is intori?",
     answer: [
       "intori helps you get useful personalized recommendations, plans, and drafts without starting from scratch every time.",
-      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape music ideas, game-day options, time plans, drafts, and more around you."
+      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape food picks, game-day options, live-music ideas, style finds, and more around you."
     ]
   },
   {
@@ -29,8 +29,8 @@ export const FAQ: FaqItem[] = [
   {
     question: "What can I start with?",
     answer: [
-      "intori starts with focused areas like better music ideas, game-day options, and planning your time.",
-      "Each area helps intori understand what you like, what you avoid, and what actually fits your life."
+      "intori starts with daily helpers like Today's Food, Game Day, live music, and Style Finds.",
+      "Each one helps intori understand what you like, what you avoid, and what actually fits your life."
     ]
   },
   {
@@ -43,8 +43,8 @@ export const FAQ: FaqItem[] = [
   {
     question: "What can intori do right now?",
     answer: [
-      "Music is the first area available.",
-      "It can help you find music ideas and live-show options that fit your taste, timing, venue comfort, and energy. Game Day and planning your time are next."
+      "Four daily helpers are live: Today's Food, Game Day, live-music ideas, and Style Finds.",
+      "Each gives you a useful first pass that fits your taste, timing, and constraints — and you can go deeper in a quick chat when you want more."
     ]
   },
   {
@@ -71,22 +71,22 @@ export const FAQ: FaqItem[] = [
   {
     question: "Where can I use intori?",
     answer: [
-      "intori is currently available through World, where it is already used by thousands of verified humans.",
-      "Broader web access is planned."
+      "intori is on the web at app.intori.co — just sign in to get started.",
+      "It is also in the World App, where it is already used by thousands of verified humans."
     ]
   },
   {
     question: "Why does intori mention verified humans?",
     answer: [
-      "World gives intori its first verified-human community.",
-      "That helps keep access fair, reduce abuse, and support trust. It is not meant to be the only way people use intori forever."
+      "World ID gives intori a verified-human trust layer and lets your personalization carry across the web and the World App.",
+      "It helps keep access fair and reduce abuse, but it is not a gate — anyone can use intori on the web."
     ]
   },
   {
     question: "What are Credits?",
     answer: [
-      "Credits are a simple way to unlock extra intori moments, like answering more questions or running more personalized recommendations.",
-      "The goal is to keep the experience easy: earn or use Credits when you want more."
+      "Credits let you run helpers and go deeper on a result.",
+      "New users get a few starter credits free, and you can buy more whenever you want."
     ]
   },
   {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { getSession } from "next-auth/react"
 import { Fragment, type CSSProperties } from 'react'
 import { MarketingFooter, MarketingHeader } from '@/components/MarketingChrome'
 import { SeoHead } from '@/lib/seo'
+import { APP_URL, WORLD_APP_URL } from '@/lib/appLinks'
 
 import styles from './index.module.css'
 
@@ -21,8 +22,6 @@ export const getServerSideProps = (async (context) => {
 
   return { props: {} }
 }) satisfies GetServerSideProps
-
-const WORLD_APP_URL = "https://world.org/mini-app?app_id=app_263f86463869627f1183badc977e21a3"
 
 const PACKS = [
   {
@@ -73,7 +72,7 @@ const HOW_STEPS = [
   {
     number: "1",
     title: "Choose where to start.",
-    body: "Start with music, sports, planning, food, travel, or another area you want intori to personalize.",
+    body: "Start with food, game day, live music, or style — the daily helpers intori personalizes for you.",
     visual: "packs",
   },
   {
@@ -85,7 +84,7 @@ const HOW_STEPS = [
   {
     number: "3",
     title: "Get picks made for you.",
-    body: "Run intori for music ideas, game-day options, time plans, drafts, and more.",
+    body: "Run intori for food picks, game-day options, live-music ideas, and style finds — then go deeper in a quick chat.",
     visual: "tools",
   },
 ]
@@ -201,7 +200,7 @@ export default function HomePage() {
     <>
       <SeoHead
         title="intori - Made for you. Within minutes."
-        description="Answer a few quick questions and intori gives you a useful first pass for music, sports, planning, drafts, and more. No prompt writing."
+        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App."
         canonicalPath="/"
         ogDescription="Answer a little. Get a useful first pass that already knows what matters to you."
         ogImageAlt="intori preview with personalized app signals"
@@ -222,20 +221,29 @@ export default function HomePage() {
                     Made for you.<br />Within minutes.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer questions, discover your identity, and power personalized experiences across apps and AI.
+                    Answer a few quick questions and intori gives you a useful first pass — for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App.
                   </p>
                   <div className={styles.heroCtas}>
                     <a
-                      href={WORLD_APP_URL}
+                      href={APP_URL}
                       className={styles.ctaPrimary}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <WorldIcon size={17} />
-                      Open on World
+                      Get started
                     </a>
                     <a href="#how-it-works" className={styles.ctaSecondary}>
                       See how it works →
+                    </a>
+                    <a
+                      href={WORLD_APP_URL}
+                      className={styles.ctaSecondary}
+                      style={{ gap: 6 }}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <WorldIcon size={16} />
+                      Also on World App
                     </a>
                   </div>
                   <div className={styles.trustRow}>
@@ -294,15 +302,15 @@ export default function HomePage() {
                     </div>
 
                     <div className={`${styles.floatCard} ${styles.floatCardThree} ${styles.floatEntranceDelay2}`}>
-                      <Image src="/brand/hero-stamps/night-owls.png" alt="" fill sizes="280px" className={styles.floatImage} />
+                      <Image src="/brand/hero-stamps/foodies.png" alt="" fill sizes="280px" className={styles.floatImage} />
                       <span className={styles.floatCheck} aria-hidden="true">
                         <svg viewBox="0 0 20 20" className={styles.floatCheckIcon}>
                           <path d="M7.8 14.2 3.7 10l1.8-1.8 2.3 2.3 6.7-6.8 1.8 1.8-8.5 8.7z" />
                         </svg>
                       </span>
                       <div className={styles.floatText}>
-                        <p className={styles.floatCardLabel}>Plan today</p>
-                        <p className={styles.floatCardTitle}>Best use of today</p>
+                        <p className={styles.floatCardLabel}>Today's Food</p>
+                        <p className={styles.floatCardTitle}>Tonight's pick, sorted</p>
                       </div>
                     </div>
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -309,8 +309,8 @@ export default function HomePage() {
                         </svg>
                       </span>
                       <div className={styles.floatText}>
-                        <p className={styles.floatCardLabel}>Today's Food</p>
-                        <p className={styles.floatCardTitle}>Tonight's pick, sorted</p>
+                        <p className={styles.floatCardLabel}>Today&apos;s Food</p>
+                        <p className={styles.floatCardTitle}>Tonight&apos;s pick, sorted</p>
                       </div>
                     </div>
 

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -3,12 +3,9 @@ import Head from 'next/head'
 import { MarketingFooter, MarketingHeader, WorldIcon } from '@/components/MarketingChrome'
 import { getAllSlugs, getPostBySlug, type Post } from '@/lib/news'
 import { SeoHead, SITE_URL, absoluteUrl } from '@/lib/seo'
+import { APP_URL, WORLD_APP_URL } from '@/lib/appLinks'
 import styles from './news.module.css'
 
-const WORLD_APP_URL =
-  'https://world.org/mini-app?app_id=app_263f86463869627f1183badc977e21a3'
-const FARCASTER_URL =
-  'https://warpcast.com/~/frames/launch?domain=frame.intori.co'
 const LAUNCH_ARTICLE_SLUG = 'intori-now-live-on-world'
 const LAUNCH_OG_IMAGE = `${SITE_URL}/news/intori-world-01.png`
 
@@ -126,18 +123,24 @@ export default function NewsPost({
           <p className={styles.ctaTagline}>
             Made for you. Within minutes.
           </p>
-          <a href={WORLD_APP_URL} className={styles.ctaPrimary}>
-            <WorldIcon size={17} />
-            Open on World
+          <a
+            href={APP_URL}
+            className={styles.ctaPrimary}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Get started
           </a>
           <div className={styles.ctaProviders}>
             <a
-              href={FARCASTER_URL}
+              href={WORLD_APP_URL}
               className={styles.ctaProviderLink}
+              style={{ gap: 6 }}
               target="_blank"
               rel="noopener noreferrer"
             >
-              Open on Farcaster
+              <WorldIcon size={15} />
+              Also on World App
             </a>
           </div>
         </div>

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -14,7 +14,7 @@ const Privacy: NextPage = () => {
 
       <LegalLayout>
         <h1>intori Privacy Policy</h1>
-        <p><strong>Last Updated: May 22, 2026</strong></p>
+        <p><strong>Last Updated: June 26, 2026</strong></p>
 
       <h2>Who we are</h2>
       <p>
@@ -48,11 +48,14 @@ const Privacy: NextPage = () => {
 
       <h3>Account and sign-in information</h3>
       <p>
-        intori does not use a traditional email-and-password account system. Depending on how you access intori, we may collect or process:
+        Depending on how you access intori, we may collect or process:
       </p>
       <ul>
+        <li>Your email address, when you sign in on the web using a one-time email magic link.</li>
+        <li>World App, World Mini App, World ID, or wallet-based identifiers, such as wallet address, username, profile image, authentication messages, signatures, nonce records, and verification results.</li>
+        <li>Apple sign-in identifiers, where Apple sign-in is available.</li>
         <li>Farcaster account identifiers, such as FID, username, display name, profile image, bio, and related public profile data.</li>
-        <li>World App, World Mini App, or wallet-based identifiers, such as wallet address, username, profile image, authentication messages, signatures, nonce records, and verification results.</li>
+        <li>Account-linking records that connect the sign-in methods you use into a single intori account, so your credits, runs, and personalization stay unified across the web and supported platforms.</li>
         <li>Session tokens and cookies used to keep you signed in.</li>
         <li>Information about the client app or platform through which you accessed intori.</li>
       </ul>
@@ -93,7 +96,7 @@ const Privacy: NextPage = () => {
 
       <h3>Payments and credits</h3>
       <p>
-        If you buy or activate paid credits, helper access, or similar features, we may store purchase reference, provider, token symbol, token amount, transaction ID, transaction hash, status, failure codes, failure reasons, confirmation time, activation time, and verification metadata. Payments may be processed through third-party wallets, World Pay, blockchain networks, or other supported payment rails. We do not collect your private keys.
+        If you buy or activate paid credits, helper access, or similar features, we may store purchase reference, provider, token symbol, token amount, transaction ID, transaction hash, status, failure codes, failure reasons, confirmation time, activation time, and verification metadata. Payments may be processed through third-party card payment processors such as Stripe, third-party wallets, World Pay, blockchain networks, or other supported payment rails. Card payments are handled by the processor; we do not store full payment card numbers, and we do not collect your private keys.
       </p>
 
       <h3>Notifications</h3>
@@ -112,7 +115,6 @@ const Privacy: NextPage = () => {
       </p>
       <ul>
         <li>Your legal name.</li>
-        <li>Your email address.</li>
         <li>Your mobile or other phone number.</li>
         <li>Government ID numbers, KYC documents, or biometric identifiers.</li>
         <li>Private keys, recovery phrases, or wallet seed phrases.</li>

--- a/pages/terms-of-use.tsx
+++ b/pages/terms-of-use.tsx
@@ -14,7 +14,7 @@ const Terms: NextPage = () => {
 
       <LegalLayout>
         <h1>intori Terms of Use</h1>
-        <p><strong>Last Updated: May 22, 2026</strong></p>
+        <p><strong>Last Updated: June 26, 2026</strong></p>
 
       <p>
         These Terms of Use (&quot;Terms&quot;) are an agreement between you and Tuum Technologies, Inc. (&quot;Tuum&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) and govern your access to and use of intori, including the intori website, mini app experiences, personal preference and context profile, credits, helper results, connected app flows, APIs, and related services (together, the &quot;Services&quot;).
@@ -41,7 +41,7 @@ const Terms: NextPage = () => {
 
       <h2>3. Accounts, wallets, and platform access</h2>
       <p>
-        intori does not currently use a traditional email-and-password account system. You may access the Services through supported platforms or wallets, such as Farcaster, World App, World Mini App, or other supported sign-in methods.
+        You may access the Services on the web at app.intori.co or through supported platforms and wallets. Supported sign-in methods include email sign-in (a one-time magic link), World App or World ID, Apple sign-in where available, and other supported methods. Where you sign in through more than one method, intori may link those identities to a single intori account so your data stays unified.
       </p>
       <p>
         You are responsible for maintaining control of your wallet, platform account, device, authentication method, and private keys. We will never ask for your private keys or recovery phrase. Transactions or actions authorized through your wallet or platform account may be irreversible.


### PR DESCRIPTION
Polishes the public marketing site for next week's Helper **gate-open**, where the web app (`app.intori.co`) becomes the primary entry point. Research/source: the V2 foundation audit register (intori-docs).

## Why
Today every "open the app" CTA points to the **World App** mini-app, sign-in copy is **Farcaster**-first, and the legal pages claim intori has **no email accounts** — all stale for V2 (web-primary, email magic-link sign-in, four live helpers, conversational go-deeper, World-ID account linkage).

## Changes
**Web-primary CTAs** (the conversion surfaces)
- New `lib/appLinks.ts` with shared `APP_URL` / `WORLD_APP_URL` (replaces the duplicated `WORLD_APP_URL` constant).
- Hero, site header, and news-article CTA bands: primary **"Get started" → app.intori.co**; World demoted to a secondary **"Also on World App"**; legacy **"Open on Farcaster"** removed.

**Product copy → V2 reality**
- Four live daily helpers (Today's Food, Game Day, live music, Style Finds) + the **go-deeper chat**, across hero, "How it works", and FAQ.
- Swapped the stale **"Plan today"** hero card (Plan My Time is now a composition connector, not a daily helper) for **Today's Food**.
- FAQ: web-primary "Where can I use intori", four-helper "what can intori do", World reframed as a **trust/identity layer** (not an access gate), Credits = starter-credits + buy (pack-earn retired).

**Legal accuracy (compliance — do before flipping sign-in on)**
- Terms §3 + Privacy no longer claim "no email-and-password accounts".
- Disclose email magic-link, World ID / Apple sign-in, **account-linking records**, and **Stripe** card processing; remove "Your email address" from the *"information we do not collect"* list.
- Bump **Last Updated → June 26, 2026** on both.

**Misc**
- Relabel the internal Farcaster `/signin` (gates `/dashboard`) as the **team dashboard login**, not a consumer path.

## Verification
- `npx tsc --noEmit` → clean (exit 0).
- No dangling references to removed constants.

## Notes / follow-ups (not in this PR)
- Consider a new gate-open **News post** so the newest article reflects V2 (the existing "intori now live on World" / "packs build your identity" posts stay as dated history).
- The Stripe disclosure is in place now; it's harmless before launch and avoids a gap when checkout flips on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)