### PR TITLE
PR2 — Hero

### DIFF
--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -295,16 +295,15 @@
   width: 290px;
   /* iPhone proportions: 390 × 844 logical pixels */
   aspect-ratio: 390 / 844;
-  background: #1A1A1E;
+  background: #EFE7D6;
   border-radius: 46px;
   border: 1.5px solid rgba(210, 210, 220, 0.20);
   transform: translateX(-54%);
   overflow: hidden;
   box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.07),
-    0 48px 96px rgba(23, 23, 56, 0.28),
-    0 20px 40px rgba(23, 23, 56, 0.14),
-    0 4px 10px rgba(23, 23, 56, 0.08);
+    0 48px 96px rgba(38, 33, 62, 0.28),
+    0 20px 40px rgba(38, 33, 62, 0.14),
+    0 4px 10px rgba(38, 33, 62, 0.08);
 }
 
 /* Dynamic island pill — renders on top of screenshot */
@@ -315,7 +314,7 @@
   transform: translateX(-50%);
   width: 33%;
   height: 27px;
-  background: #0c0c10;
+  background: #26213E;
   border-radius: 14px;
   z-index: 10;
   pointer-events: none;
@@ -330,7 +329,7 @@
   bottom: 8px;
   border-radius: 39px;
   overflow: hidden;
-  background: #050508;
+  background: #FFFFFF;
 }
 
 .heroPhoneScreenshot {
@@ -347,20 +346,8 @@
   display: flex;
   flex-direction: column;
   padding: 58px 18px 18px;
-  background:
-    linear-gradient(180deg, rgba(38, 31, 86, 0.98) 0%, #171738 46%, #101024 100%);
-  color: #fff;
-}
-
-.heroPhoneResult::before {
-  content: "";
-  position: absolute;
-  inset: 128px 0 auto;
-  height: 220px;
-  background: linear-gradient(90deg, rgba(212, 103, 255, 0.16), rgba(213, 247, 78, 0.08), rgba(96, 179, 215, 0.14));
-  filter: blur(32px);
-  opacity: 0.65;
-  pointer-events: none;
+  background: #FFFFFF;
+  color: #26213E;
 }
 
 .heroResultTop,
@@ -390,26 +377,26 @@
   display: inline-flex;
   align-items: center;
   min-height: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid #E9E2D3;
   border-radius: 999px;
   padding: 0 10px;
-  background: rgba(255, 255, 255, 0.07);
+  background: #FAF3E6;
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0;
 }
 
 .heroResultPill {
-  color: var(--lime);
+  color: #26213E;
 }
 
 .heroResultFresh {
-  color: rgba(255, 255, 255, 0.68);
+  color: rgba(38, 33, 62, 0.62);
 }
 
 .heroResultKicker {
   margin: 0 0 8px;
-  color: rgba(255, 255, 255, 0.62);
+  color: rgba(38, 33, 62, 0.5);
   font-size: 10px;
   font-weight: 850;
   letter-spacing: 0.08em;
@@ -419,7 +406,7 @@
 
 .heroResultTitle {
   margin: 0;
-  color: #fff;
+  color: #26213E;
   font-size: 25px;
   font-weight: 900;
   letter-spacing: 0;
@@ -428,7 +415,7 @@
 
 .heroResultRequest {
   margin: 12px 0 12px;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 12px;
   font-weight: 600;
   line-height: 1.45;
@@ -437,7 +424,16 @@
 .heroResultReceipt {
   align-self: flex-start;
   margin-bottom: 14px;
-  color: var(--lime);
+  color: #26213E;
+}
+
+.heroResultReceipt::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: #93B32A;
 }
 
 .heroResultList {
@@ -450,21 +446,21 @@
   display: flex;
   flex-direction: column;
   gap: 3px;
-  border: 1px solid rgba(255, 255, 255, 0.10);
+  border: 1px solid #E9E2D3;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.075);
+  background: #FAF3E6;
   padding: 10px 11px;
 }
 
 .heroResultItem strong {
-  color: #fff;
+  color: #26213E;
   font-size: 13px;
   font-weight: 850;
   line-height: 1.15;
 }
 
 .heroResultItem span {
-  color: rgba(255, 255, 255, 0.66);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10.5px;
   font-weight: 600;
   line-height: 1.35;
@@ -472,7 +468,7 @@
 
 .heroResultNote {
   margin: 12px 0 10px;
-  color: rgba(255, 255, 255, 0.52);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10.5px;
   font-weight: 650;
   line-height: 1.35;
@@ -491,14 +487,14 @@
 
 .heroResultCta {
   min-height: 42px;
-  background: var(--lime);
-  color: var(--ink);
+  background: #26213E;
+  color: #FCF8F1;
   font-size: 14px;
 }
 
 .heroResultSecondary {
   min-height: 34px;
-  color: rgba(255, 255, 255, 0.58);
+  color: rgba(38, 33, 62, 0.55);
   font-size: 12px;
 }
 
@@ -511,12 +507,9 @@
   aspect-ratio: 1;
   overflow: hidden;
   border-radius: 18px;
-  background: #171738;
-  border: 3px solid rgba(96, 179, 215, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(96, 179, 215, 0.22);
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  box-shadow: var(--shadow-card);
   padding: 0;
   isolation: isolate;
 }
@@ -526,26 +519,8 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  background:
-    linear-gradient(180deg, rgba(8, 8, 24, 0.02) 0%, rgba(8, 8, 24, 0.12) 42%, rgba(8, 8, 24, 0.78) 100%),
-    linear-gradient(90deg, rgba(8, 8, 24, 0.18) 0%, rgba(8, 8, 24, 0.00) 58%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 42%, rgba(255, 255, 255, 0.88) 100%);
   pointer-events: none;
-}
-
-.floatCardMusic {
-  border-color: rgba(212, 103, 255, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(212, 103, 255, 0.24);
-}
-
-.floatCardThree {
-  border-color: rgba(213, 247, 78, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(213, 247, 78, 0.22);
 }
 
 .floatText {
@@ -558,7 +533,7 @@
 
 .floatCardLabel {
   margin: 0 0 5px;
-  color: rgba(255, 255, 255, 0.74);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10px;
   font-weight: 800;
   line-height: 1;
@@ -569,11 +544,10 @@
 .floatCardTitle {
   max-width: 164px;
   margin: 0;
-  color: #fff;
+  color: #26213E;
   font-size: 17px;
   font-weight: 900;
   line-height: 1.1;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.34);
 }
 
 .floatImage {
@@ -597,9 +571,9 @@
   width: 34px;
   height: 34px;
   border-radius: 999px;
-  background: var(--lime);
-  color: var(--ink);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  background: #26213E;
+  color: #FCF8F1;
+  box-shadow: 0 2px 8px rgba(38, 33, 62, 0.18);
 }
 
 .floatCheckIcon {
@@ -870,17 +844,16 @@
   position: relative;
   width: 150px;
   aspect-ratio: 390 / 844;
-  background: #1A1A1E;
+  background: #EFE7D6;
   border-radius: 26px;
   border: 1.5px solid rgba(210, 210, 220, 0.18);
   overflow: hidden;
   transform: rotate(4deg);
   transform-origin: 50% 60%;
   box-shadow:
-    inset 0 0 0 0.5px rgba(255, 255, 255, 0.08),
-    0 40px 80px rgba(23, 23, 56, 0.36),
-    0 16px 32px rgba(23, 23, 56, 0.20),
-    0 4px 10px rgba(23, 23, 56, 0.08);
+    0 40px 80px rgba(38, 33, 62, 0.36),
+    0 16px 32px rgba(38, 33, 62, 0.20),
+    0 4px 10px rgba(38, 33, 62, 0.08);
 }
 
 .howPackPhoneScreen {
@@ -891,7 +864,7 @@
   bottom: 5px;
   border-radius: 21px;
   overflow: hidden;
-  background: #050508;
+  background: #FFFFFF;
 }
 
 .howPackPhoneScreenshot {
@@ -910,7 +883,7 @@
   transform: translateX(-50%);
   width: 32%;
   height: 15px;
-  background: #0c0c10;
+  background: #26213E;
   border-radius: 8px;
   z-index: 5;
   pointer-events: none;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -139,7 +139,7 @@ function HeroPhone() {
       <div className={styles.heroPhoneScreenSlot}>
         <Image
           src="/brand/era2/hero-intori-music-pack-ready.jpg"
-          alt="intori music pack ready screen"
+          alt="intori Today's Food result on the web app"
           width={1206}
           height={2622}
           className={styles.heroPhoneScreenshot}
@@ -200,7 +200,7 @@ export default function HomePage() {
     <>
       <SeoHead
         title="intori - Made for you. Within minutes."
-        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App."
+        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App."
         canonicalPath="/"
         ogDescription="Answer a little. Get a useful first pass that already knows what matters to you."
         ogImageAlt="intori preview with personalized app signals"
@@ -221,7 +221,7 @@ export default function HomePage() {
                     Made for you.<br />Within minutes.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer a few quick questions and intori gives you a useful first pass — for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App.
+                    Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App.
                   </p>
                   <div className={styles.heroCtas}>
                     <a
@@ -263,7 +263,7 @@ export default function HomePage() {
                         className={styles.worldBadge}
                       />
                       <p className={styles.trustCopy}>
-                        Already used by <strong>5,500+</strong> verified humans on World
+                        Already used by <strong>6,655+</strong> verified humans on World
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## PR2 — Hero

Warms the hero visual and fixes copy/stat honesty. **Stacked on PR1** (base = `warm/01-foundation-chrome`).

Follows `docs/internal/warm-polish-build-plan-2026-07-08.md` §PR2.

### Changes
**`pages/index.tsx`**
- Trust stat `5,500+` → `6,655+`.
- Hero body rewritten with no em dashes: *"Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App."*
- Hero image `alt` → `intori Today's Food result on the web app`.
- Homepage `<Seo description>` aligned to the same no-em-dash hero copy (it was the meta-description twin of the hero body).

**`pages/index.module.css`**
- Deleted the `.heroPhoneResult::before` aurora blur.
- Both phone mocks warm: shells `#1A1A1E`→`#EFE7D6`, screens `#050508`→`#FFFFFF`, islands `#0c0c10`→`#26213E`; box-shadows retinted navy→plum.
- In-mock result UI → light warm surface (white bg, ink text, `#FAF3E6` chips/items + `#E9E2D3` borders, ink CTA + cream text, a `#93B32A` spark dot before the receipt as a non-text accent).
- Float cards → white with `1px #E9E2D3` hairline + `var(--shadow-card)`; stripped blue/purple/lime neon borders and `0 0 Npx` glows; dark scrim → light scrim so ink text stays readable; label/title → ink; check chip → ink bg + cream check. **Cluster artwork preserved.**

### Notes / deviations
- **Removed the vestigial white glass-edge inset highlights** (`inset 0 0 0 1px rgba(255,255,255,.07)`) from both phone shells. Spec said "keep geometry," but these are invisible on a warm bezel *and* they matched the Appendix-A glow grep (`0 0 1px rgba…`). Dropping them keeps the final grep clean; drop-shadow depth is preserved.
- **Phone screens still show the old dark/neon screenshot images** (`hero-intori-music-pack-ready.jpg`, `pack-question-music.png`). These are `.jpg`/`.png` assets, not CSS — PR7 swaps the real warm screenshots. The bezel/island/frame around them are warm now.
- `.heroPhoneResult` result-UI CSS appears **not currently rendered** by `HeroPhone` (the screenshot image is used instead). I converted it per spec regardless; it's harmless if it stays dead, and correct if it's ever re-enabled.

### Verification
- `npm run lint` → clean.
- Logged-out local render: warm cream bezels + plum islands; all three float cards white with ink text + ink check badges (artwork intact); stat `6,655+`; no aurora; glow grep clean on hero rules; no `var(--lime)`/`#171738`/`#60B3D7` in hero rules.

> Stacked-PR series — re-target to `helper-launch/web-primary-v2` on merge, after PR1. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
