### PR TITLE
PR3 — How it works + Why grid

### DIFF
--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -664,7 +664,7 @@
   scroll-margin-top: 104px;
   padding: 80px 0 72px;
   border-top: 1px solid var(--hairline);
-  background: #fff;
+  background: #FFFFFF;
 }
 
 .sectionHeading {
@@ -696,6 +696,7 @@
   border: 1px solid var(--hairline);
   border-radius: 12px;
   background: var(--ground);
+  box-shadow: var(--shadow-card);
   padding: 26px 24px 24px;
   overflow: hidden;
   isolation: isolate;
@@ -709,8 +710,8 @@
 
 .howCard:hover {
   z-index: 4;
-  border-color: rgba(23, 23, 56, 0.14);
-  box-shadow: 0 18px 38px rgba(23, 23, 56, 0.10);
+  border-color: rgba(38, 33, 62, 0.14);
+  box-shadow: 0 18px 38px rgba(38, 33, 62, 0.10);
   transform: translateY(-3px) scale(1.025);
 }
 
@@ -724,7 +725,7 @@
   height: 34px;
   margin-bottom: 18px;
   border-radius: 999px;
-  background: rgba(213, 247, 78, 0.35);
+  background: #FAF3E6;
   color: var(--ink);
   font-size: 16px;
   font-weight: 900;
@@ -765,25 +766,16 @@
 }
 
 .howCardPack {
-  border: 2px solid rgba(212, 103, 255, 0.74);
-  background:
-    radial-gradient(circle at 82% 34%, rgba(212, 103, 255, 0.22), transparent 34%),
-    radial-gradient(circle at 15% 100%, rgba(213, 247, 78, 0.10), transparent 38%),
-    linear-gradient(135deg, #171738 0%, #202047 58%, #2f2046 100%);
-  box-shadow:
-    0 16px 34px rgba(23, 23, 56, 0.14),
-    0 0 28px rgba(212, 103, 255, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border: 1px solid #E9E2D3;
+  background: #FFFFFF;
+  box-shadow: var(--shadow-card);
 }
 
 .howCardPack:hover {
-  border-color: rgba(212, 103, 255, 0.92);
+  border-color: var(--hairline);
   box-shadow:
-    0 18px 42px rgba(23, 23, 56, 0.16),
-    0 0 34px rgba(212, 103, 255, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    0 1px 2px rgba(38, 33, 62, 0.05),
+    0 22px 46px -16px rgba(38, 33, 62, 0.24);
 }
 
 .howPackCardBackdrop {
@@ -798,8 +790,8 @@
 .howPackCardImage {
   object-fit: cover;
   object-position: center 24%;
-  opacity: 0.30;
-  filter: saturate(1.1) contrast(1.02);
+  opacity: 0.14;
+  filter: saturate(1.05) contrast(1.02);
 }
 
 .howPackCardVignette {
@@ -807,8 +799,8 @@
   inset: 0;
   z-index: 1;
   background:
-    linear-gradient(180deg, rgba(8, 8, 24, 0.04) 0%, rgba(8, 8, 24, 0.18) 42%, rgba(8, 8, 24, 0.78) 100%),
-    linear-gradient(90deg, rgba(8, 8, 24, 0.86) 0%, rgba(8, 8, 24, 0.55) 58%, rgba(8, 8, 24, 0.18) 100%);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.72) 100%),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.86) 0%, rgba(255, 255, 255, 0.45) 58%, rgba(255, 255, 255, 0.10) 100%);
 }
 
 .howPackCardIcon {
@@ -818,24 +810,23 @@
   right: 20px;
   width: 106px;
   height: 106px;
-  opacity: 0.24;
-  filter: brightness(0) invert(1);
+  opacity: 0.08;
+  filter: brightness(0);
   transform: translateY(-50%);
 }
 
 .howCardPack .howCardStep {
-  background: var(--lime);
+  background: #FAF3E6;
   color: var(--ink);
-  box-shadow: 0 0 18px rgba(213, 247, 78, 0.28);
 }
 
 .howCardPack .howCardTitle {
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
 }
 
 .howCardPack .howCardBody {
   max-width: 188px;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--ink-soft);
 }
 
 /* Step 1 phone — full shell, proportional to hero, no rotation lock */
@@ -889,28 +880,37 @@
   pointer-events: none;
 }
 
-/* Tool logos in step 3 */
+/* Step 3 "see more" mini */
 
-.toolMiniRow {
+.seeMoreMini {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
 }
 
-.toolMini {
+.seeMoreBubble {
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  border-radius: 12px 12px 12px 4px;
+  padding: 8px 11px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #26213E;
+  box-shadow: var(--shadow-card);
+}
+
+.seeMoreChip {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border: 1px solid var(--hairline);
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 14px rgba(23, 23, 56, 0.05);
-}
-
-.toolMini .toolLogo {
-  width: 24px;
-  height: 24px;
+  gap: 6px;
+  background: #FAF3E6;
+  border: 1px solid #E9E2D3;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 800;
+  color: #26213E;
 }
 
 /* ─── Packs section ───────────────────────────────────── */
@@ -918,7 +918,7 @@
 .packsSection {
   scroll-margin-top: 104px;
   padding: 80px 0 72px;
-  background: var(--ground);
+  background: var(--plane);
   border-top: 1px solid var(--hairline);
 }
 
@@ -940,35 +940,15 @@
 .packTile {
   position: relative;
   min-height: 248px;
-  border: 2px solid color-mix(in srgb, var(--pack-color) 34%, rgba(23, 23, 56, 0.08));
+  border: 1px solid #E9E2D3;
   border-radius: 18px;
-  background:
-    radial-gradient(circle at 88% 6%, color-mix(in srgb, var(--pack-color) 16%, transparent), transparent 38%),
-    radial-gradient(circle at 8% 100%, rgba(213, 247, 78, 0.12), transparent 42%),
-    linear-gradient(180deg, #FFFFFF 0%, #FBFBF6 58%, color-mix(in srgb, var(--pack-color) 7%, #F4F4F0) 100%);
+  background: #FFFFFF;
   padding: 0 18px 16px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   isolation: isolate;
-  box-shadow:
-    0 16px 30px rgba(23, 23, 56, 0.07),
-    0 0 22px color-mix(in srgb, var(--pack-color) 10%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.84);
-}
-
-.packTile::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.72), transparent 44%),
-    linear-gradient(90deg, color-mix(in srgb, var(--pack-color) 8%, transparent), transparent 46%);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.72),
-    inset 0 -1px 0 color-mix(in srgb, var(--pack-color) 10%, transparent);
-  border-radius: inherit;
+  box-shadow: var(--shadow-card);
 }
 
 .packIconBand {
@@ -978,9 +958,7 @@
   height: 76px;
   margin: 0 -18px 16px;
   padding: 16px 18px;
-  background:
-    radial-gradient(circle at 24px 20px, color-mix(in srgb, var(--pack-color) 18%, transparent), transparent 44px),
-    linear-gradient(180deg, color-mix(in srgb, var(--pack-color) 9%, #fff), rgba(255, 255, 255, 0));
+  background: color-mix(in srgb, var(--pack-color) 8%, #fff);
 }
 
 .packIconBand::after {
@@ -1001,14 +979,12 @@
   width: 52px;
   height: 52px;
   margin-bottom: 0;
-  border: 2px solid;
+  border: 1px solid #E9E2D3;
   border-radius: 16px;
   flex-shrink: 0;
   overflow: hidden;
   z-index: 1;
-  box-shadow:
-    0 8px 18px color-mix(in srgb, var(--pack-color) 30%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.32);
+  background: color-mix(in srgb, var(--pack-color) 16%, #fff);
 }
 
 .packIconWrap::after {
@@ -1024,7 +1000,6 @@
   z-index: 1;
   width: 30px;
   height: 30px;
-  filter: brightness(0) invert(1);
 }
 
 .packLabel {
@@ -1037,7 +1012,7 @@
 
 .packDesc {
   margin: 0;
-  color: rgba(22, 24, 35, 0.66);
+  color: var(--ink-soft);
   font-size: 12.5px;
   font-weight: 550;
   line-height: 1.5;
@@ -1051,13 +1026,14 @@
   min-height: 24px;
   padding: 0 9px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--pack-color) 12%, #FFFFFF);
+  background: #FAF3E6;
+  color: var(--ink-soft);
   margin-top: 12px;
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  border: 1px solid color-mix(in srgb, var(--pack-color) 28%, rgba(23, 23, 56, 0.08));
+  border: 1px solid #E9E2D3;
 }
 
 /* ─── AI / Use where you are ─────────────────────────── */

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,7 @@ const PACKS = [
     label: 'Knows when to ask more',
     desc: 'When it needs more context, intori asks one focused question instead of guessing.',
     badge: 'No guessing',
-    color: '#60B3D7',
+    color: '#D467FF',
   },
   {
     icon: '/brand/icons/sports_fans.svg',
@@ -57,14 +57,14 @@ const PACKS = [
     label: 'Fresh where it matters',
     desc: 'Music, sports, food, and plans can include source and freshness notes.',
     badge: 'Fresh context',
-    color: '#60B3D7',
+    color: '#F76B15',
   },
   {
-    icon: '/brand/icons/travel_enthusiasts.svg',
-    label: 'Easy to continue',
-    desc: 'Take the first pass into ChatGPT, Claude, Gemini, or a trusted app.',
-    badge: 'Continue',
-    color: '#60B3D7',
+    icon: '/brand/icons/casual_socializers.svg',
+    label: 'See more, in-app',
+    desc: 'Each helper opens with a warm intro, shows picks made for you, and lets you look further.',
+    badge: 'See more',
+    color: '#FF5C8A',
   },
 ]
 
@@ -72,7 +72,7 @@ const HOW_STEPS = [
   {
     number: "1",
     title: "Choose where to start.",
-    body: "Start with food, game day, live music, or style — the daily helpers intori personalizes for you.",
+    body: "Start with food, game day, live music, or style, the daily helpers intori personalizes for you.",
     visual: "packs",
   },
   {
@@ -84,7 +84,7 @@ const HOW_STEPS = [
   {
     number: "3",
     title: "Get picks made for you.",
-    body: "Run intori for food picks, game-day options, live-music ideas, and style finds — then go deeper in a quick chat.",
+    body: "Run intori for food picks, game-day plans, live-music ideas, and style finds, then see more in a quick chat inside intori.",
     visual: "tools",
   },
 ]
@@ -178,10 +178,9 @@ function HowVisual({ type }: { type: string }) {
 
   if (type === "tools") {
     return (
-      <div className={styles.toolMiniRow} aria-hidden="true">
-        <span className={styles.toolMini}><ChatGPTLogo /></span>
-        <span className={styles.toolMini}><ClaudeLogo /></span>
-        <span className={styles.toolMini}><GeminiLogo /></span>
+      <div className={styles.seeMoreMini} aria-hidden="true">
+        <span className={styles.seeMoreBubble}>Here&rsquo;s your first pass</span>
+        <span className={styles.seeMoreChip}>See more &rarr;</span>
       </div>
     )
   }
@@ -363,7 +362,7 @@ export default function HomePage() {
             </div>
           </section>
 
-          <section id="packs" className={styles.packsSection}>
+          <section id="why" className={styles.packsSection}>
             <div className={styles.container}>
               <h2 className={styles.sectionHeading}>Why intori gets more useful</h2>
               <p className={styles.packsSub}>Your answers teach intori what matters, when to ask for more, and how to explain the first pass it gives you.</p>
@@ -375,20 +374,13 @@ export default function HomePage() {
                     style={{ '--pack-color': pack.color } as CSSProperties}
                   >
                     <div className={styles.packIconBand}>
-                      <div
-                        className={styles.packIconWrap}
-                        style={{
-                          background: pack.color,
-                          borderColor: `${pack.color}f0`,
-                          boxShadow: `0 0 22px ${pack.color}66`,
-                        }}
-                      >
+                      <div className={styles.packIconWrap}>
                         <Image src={pack.icon} alt="" width={34} height={34} className={styles.packIcon} />
                       </div>
                     </div>
                     <p className={styles.packLabel}>{pack.label}</p>
                     <p className={styles.packDesc}>{pack.desc}</p>
-                    <span className={styles.packCluster} style={{ color: pack.color }}>{pack.badge}</span>
+                    <span className={styles.packCluster}>{pack.badge}</span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## PR3 — How it works + Why grid

Warms the How steps and the Why grid, and removes the external-AI framing from step 3 and the old "Easy to continue" tile. **Stacked on PR2** (base = `warm/02-hero`).

Follows `docs/internal/warm-polish-build-plan-2026-07-08.md` §PR3.

### `pages/index.tsx`
- **PACKS:** retired `#60B3D7` (crypto blue) — `[1]`→`#D467FF`, `[4]`→`#F76B15`. Rewrote tile 6 (`Easy to continue` → **"See more, in-app"**: warm intro, picks made for you, look further; badge "See more"; `#FF5C8A`).
- Removed the inline glow on `.packIconWrap` (`background`/`borderColor`/`boxShadow`) and the inline **cluster color on `.packCluster`** (was a cluster color as *text*). CSS now renders calm thumbs + an ink-soft badge.
- **HowVisual "tools" branch** → honest "Here's your first pass" + "See more →" mock (no ChatGPT/Claude/Gemini logos). The logo components stay for now — still used by the AI section, deleted in PR4.
- Copy: `HOW_STEPS[2]` rewritten to the no-em-dash "…food picks, game-day plans, live-music ideas, and style finds, then see more in a quick chat inside intori." Also de-em-dashed `HOW_STEPS[0]`.
- Anchor: `id="packs"` → `id="why"` (matches the PR1 nav href).

### `pages/index.module.css`
- **How:** cards get `var(--shadow-card)`; step badges `rgba(213,247,78,.35)` → `#FAF3E6` (ink numeral). `.howCardPack`: dark-indigo gradient + purple/lime radials + glows → white card + `#E9E2D3` border + shadow-card; hover glow → stronger shadow; pack-card title/body → ink/ink-soft; backdrop image + vignette lightened so the art reads on white. Deleted `.toolMiniRow`/`.toolMini`; added `.seeMoreMini`/`.seeMoreBubble`/`.seeMoreChip`.
- **Why:** section → `--plane`. Tiles: neon-lime radial + cool base + `0 0 22px` glow → white + `#E9E2D3` + shadow-card; dropped the color-wash `::after`; icon band → soft 8% pack-color tint; icon thumb → calm 16% tint + hairline (removed the pack-color glow *and* the whitening filter so icons read dark); badge → `#FAF3E6` + ink-soft + hairline; `packDesc` → ink-soft.

### Notes / deviations
- **Pack icons render dark-navy (native `#171738`) as an interim.** I removed the `brightness(0) invert(1)` whitening filter so the icons show on the light thumbs. PR7's icon ink-swap (`#171738`→`#26213E` in the SVG assets) makes them exactly ink with no further CSS change. (`#171738` lives only inside the `public/` SVGs, not in scanned source.)
- Retinted the incidental navy `.howCard:hover` shadow to plum for consistency (not explicitly in the spec table).
- Step-2 backdrop art is intentionally washed near-invisible for now; PR7 swaps a real warm product screenshot there.

### Verification
- `npm run lint` → clean.
- Logged-out local render + computed styles: step badges warm; `.howCardPack` white with ink text; **step-3 shows the see-more mock, no AI logos**; all 6 why tiles white (`rgb(255,255,255)`) with `var(--shadow-card)`, calm thumbs, dark icons; badge color `rgba(38,33,62,.62)` on `#FAF3E6` (no cluster-color text); no `#60B3D7`; no glows; anchor `#why`.

> Stacked-PR series — re-target to `helper-launch/web-primary-v2` on merge, after PR1→PR2. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
