### PR TITLE
PR4 — AI section rebuild + Dev bridge + component deletion

### DIFF
--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -20,11 +20,6 @@
   --radius-card: 22px;
   --radius-img: 16px;
 
-  /* TEMP legacy tokens — still referenced by rules converted in PR2–PR4; removed in those PRs */
-  --lime:      #D5F74E;
-  --dark-bg:   #171738;
-  --dark-mid:  #1F1F43;
-
   width: 100%;
   background: var(--ground);
   color: var(--ink);
@@ -1076,32 +1071,51 @@
   line-height: 1.6;
 }
 
-.toolPills {
+.helperPeek {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  align-items: flex-start;
+  gap: 8px;
+  background: linear-gradient(180deg, #FFFFFF, #FAF3E6);
+  border: 1px solid #E9E2D3;
+  border-radius: var(--radius-card);
+  padding: 22px;
+  box-shadow: var(--shadow-card);
 }
 
-.toolPill {
+.peekBubble {
+  margin: 0;
+  background: #F3ECDD;
+  border-radius: 12px 12px 12px 4px;
+  padding: 9px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #26213E;
+  max-width: 80%;
+}
+
+.peekResult {
+  margin: 0;
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  border-radius: 10px;
+  padding: 9px 12px;
+  font-size: 14px;
+  font-weight: 800;
+  color: #26213E;
+}
+
+.peekMore {
   display: inline-flex;
   align-items: center;
-  gap: 16px;
-  min-height: 68px;
-  padding: 0 28px;
-  border: 1px solid var(--hairline);
-  border-radius: 12px;
-  background: #fff;
-  color: var(--ink);
-  font-size: 18px;
+  gap: 6px;
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  border-radius: 999px;
+  padding: 7px 13px;
+  font-size: 12px;
   font-weight: 800;
-  letter-spacing: -0.01em;
-  box-shadow: 0 8px 20px rgba(23, 23, 56, 0.05);
-}
-
-.toolLogo {
-  width: 26px;
-  height: 26px;
-  flex-shrink: 0;
+  color: #26213E;
 }
 
 /* ─── Developer bridge ────────────────────────────────── */
@@ -1117,18 +1131,12 @@
   gap: 48px;
   align-items: center;
   min-height: 240px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid #EAD9C8;
   border-radius: 18px;
-  background:
-    radial-gradient(circle at 80% 18%, rgba(96, 179, 215, 0.16), transparent 34%),
-    radial-gradient(circle at 8% 100%, rgba(213, 247, 78, 0.10), transparent 36%),
-    linear-gradient(135deg, var(--ink) 0%, var(--dark-mid) 100%);
-  color: #fff;
+  background: linear-gradient(135deg, #FFFFFF, #F3ECDD);
+  color: #26213E;
   padding: 40px 40px 40px 44px;
-  box-shadow:
-    0 18px 42px rgba(23, 23, 56, 0.14),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow: var(--shadow-card);
 }
 
 .devBridgeLeft {
@@ -1140,7 +1148,7 @@
 
 .devBridgeHeading {
   margin: 0;
-  color: #fff;
+  color: #26213E;
   font-size: 28px;
   font-weight: 900;
   letter-spacing: -0.02em;
@@ -1150,7 +1158,7 @@
 .devBridgeBody {
   max-width: 260px;
   margin: 0;
-  color: rgba(255, 255, 255, 0.68);
+  color: rgba(38, 33, 62, 0.62);
   font-size: 14px;
   font-weight: 550;
   line-height: 1.55;
@@ -1162,8 +1170,8 @@
   min-height: 44px;
   padding: 0 22px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: rgba(255, 255, 255, 0.42);
+  border: 1px solid #E9E2D3;
+  color: rgba(38, 33, 62, 0.42);
   font-size: 14px;
   font-weight: 700;
   cursor: default;
@@ -1180,9 +1188,9 @@
 .devFlowCard,
 .devFlowCode {
   min-height: 160px;
-  border: 1px solid rgba(255, 255, 255, 0.09);
+  border: 1px solid #EAD9C8;
   border-radius: 10px;
-  background: rgba(255, 255, 255, 0.045);
+  background: #FFFFFF;
   padding: 22px;
 }
 
@@ -1194,20 +1202,20 @@
 
 .devFlowCard strong,
 .devFlowCode strong {
-  color: #fff;
+  color: #26213E;
   font-size: 13px;
   font-weight: 800;
 }
 
 .devFlowCard span:not(.checkLine) {
-  color: rgba(255, 255, 255, 0.65);
+  color: rgba(38, 33, 62, 0.62);
   font-size: 13px;
   font-weight: 550;
   line-height: 1.5;
 }
 
 .checkLine {
-  color: rgba(255, 255, 255, 0.82);
+  color: #26213E;
   font-size: 13px;
   font-weight: 650;
 }
@@ -1221,15 +1229,15 @@
   height: 16px;
   margin-right: 8px;
   border-radius: 4px;
-  background: var(--lime);
-  color: var(--ink);
+  background: #26213E;
+  color: #FCF8F1;
   font-size: 11px;
   font-weight: 900;
   vertical-align: -2px;
 }
 
 .devArrow {
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(38, 33, 62, 0.3);
   font-size: 22px;
   font-weight: 700;
   text-align: center;
@@ -1242,7 +1250,7 @@
 }
 
 .devFlowCode code {
-  color: var(--lime);
+  color: #26213E;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 12px;
   font-weight: 600;

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -664,7 +664,7 @@
   scroll-margin-top: 104px;
   padding: 80px 0 72px;
   border-top: 1px solid var(--hairline);
-  background: #fff;
+  background: #FFFFFF;
 }
 
 .sectionHeading {
@@ -696,6 +696,7 @@
   border: 1px solid var(--hairline);
   border-radius: 12px;
   background: var(--ground);
+  box-shadow: var(--shadow-card);
   padding: 26px 24px 24px;
   overflow: hidden;
   isolation: isolate;
@@ -709,8 +710,8 @@
 
 .howCard:hover {
   z-index: 4;
-  border-color: rgba(23, 23, 56, 0.14);
-  box-shadow: 0 18px 38px rgba(23, 23, 56, 0.10);
+  border-color: rgba(38, 33, 62, 0.14);
+  box-shadow: 0 18px 38px rgba(38, 33, 62, 0.10);
   transform: translateY(-3px) scale(1.025);
 }
 
@@ -724,7 +725,7 @@
   height: 34px;
   margin-bottom: 18px;
   border-radius: 999px;
-  background: rgba(213, 247, 78, 0.35);
+  background: #FAF3E6;
   color: var(--ink);
   font-size: 16px;
   font-weight: 900;
@@ -765,25 +766,16 @@
 }
 
 .howCardPack {
-  border: 2px solid rgba(212, 103, 255, 0.74);
-  background:
-    radial-gradient(circle at 82% 34%, rgba(212, 103, 255, 0.22), transparent 34%),
-    radial-gradient(circle at 15% 100%, rgba(213, 247, 78, 0.10), transparent 38%),
-    linear-gradient(135deg, #171738 0%, #202047 58%, #2f2046 100%);
-  box-shadow:
-    0 16px 34px rgba(23, 23, 56, 0.14),
-    0 0 28px rgba(212, 103, 255, 0.16),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border: 1px solid #E9E2D3;
+  background: #FFFFFF;
+  box-shadow: var(--shadow-card);
 }
 
 .howCardPack:hover {
-  border-color: rgba(212, 103, 255, 0.92);
+  border-color: var(--hairline);
   box-shadow:
-    0 18px 42px rgba(23, 23, 56, 0.16),
-    0 0 34px rgba(212, 103, 255, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    0 1px 2px rgba(38, 33, 62, 0.05),
+    0 22px 46px -16px rgba(38, 33, 62, 0.24);
 }
 
 .howPackCardBackdrop {
@@ -798,8 +790,8 @@
 .howPackCardImage {
   object-fit: cover;
   object-position: center 24%;
-  opacity: 0.30;
-  filter: saturate(1.1) contrast(1.02);
+  opacity: 0.14;
+  filter: saturate(1.05) contrast(1.02);
 }
 
 .howPackCardVignette {
@@ -807,8 +799,8 @@
   inset: 0;
   z-index: 1;
   background:
-    linear-gradient(180deg, rgba(8, 8, 24, 0.04) 0%, rgba(8, 8, 24, 0.18) 42%, rgba(8, 8, 24, 0.78) 100%),
-    linear-gradient(90deg, rgba(8, 8, 24, 0.86) 0%, rgba(8, 8, 24, 0.55) 58%, rgba(8, 8, 24, 0.18) 100%);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.72) 100%),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.86) 0%, rgba(255, 255, 255, 0.45) 58%, rgba(255, 255, 255, 0.10) 100%);
 }
 
 .howPackCardIcon {
@@ -818,24 +810,23 @@
   right: 20px;
   width: 106px;
   height: 106px;
-  opacity: 0.24;
-  filter: brightness(0) invert(1);
+  opacity: 0.08;
+  filter: brightness(0);
   transform: translateY(-50%);
 }
 
 .howCardPack .howCardStep {
-  background: var(--lime);
+  background: #FAF3E6;
   color: var(--ink);
-  box-shadow: 0 0 18px rgba(213, 247, 78, 0.28);
 }
 
 .howCardPack .howCardTitle {
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
 }
 
 .howCardPack .howCardBody {
   max-width: 188px;
-  color: rgba(255, 255, 255, 0.74);
+  color: var(--ink-soft);
 }
 
 /* Step 1 phone — full shell, proportional to hero, no rotation lock */
@@ -889,28 +880,37 @@
   pointer-events: none;
 }
 
-/* Tool logos in step 3 */
+/* Step 3 "see more" mini */
 
-.toolMiniRow {
+.seeMoreMini {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
 }
 
-.toolMini {
+.seeMoreBubble {
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  border-radius: 12px 12px 12px 4px;
+  padding: 8px 11px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #26213E;
+  box-shadow: var(--shadow-card);
+}
+
+.seeMoreChip {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border: 1px solid var(--hairline);
-  border-radius: 10px;
-  background: #fff;
-  box-shadow: 0 6px 14px rgba(23, 23, 56, 0.05);
-}
-
-.toolMini .toolLogo {
-  width: 24px;
-  height: 24px;
+  gap: 6px;
+  background: #FAF3E6;
+  border: 1px solid #E9E2D3;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 800;
+  color: #26213E;
 }
 
 /* ─── Packs section ───────────────────────────────────── */
@@ -918,7 +918,7 @@
 .packsSection {
   scroll-margin-top: 104px;
   padding: 80px 0 72px;
-  background: var(--ground);
+  background: var(--plane);
   border-top: 1px solid var(--hairline);
 }
 
@@ -940,35 +940,15 @@
 .packTile {
   position: relative;
   min-height: 248px;
-  border: 2px solid color-mix(in srgb, var(--pack-color) 34%, rgba(23, 23, 56, 0.08));
+  border: 1px solid #E9E2D3;
   border-radius: 18px;
-  background:
-    radial-gradient(circle at 88% 6%, color-mix(in srgb, var(--pack-color) 16%, transparent), transparent 38%),
-    radial-gradient(circle at 8% 100%, rgba(213, 247, 78, 0.12), transparent 42%),
-    linear-gradient(180deg, #FFFFFF 0%, #FBFBF6 58%, color-mix(in srgb, var(--pack-color) 7%, #F4F4F0) 100%);
+  background: #FFFFFF;
   padding: 0 18px 16px;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   isolation: isolate;
-  box-shadow:
-    0 16px 30px rgba(23, 23, 56, 0.07),
-    0 0 22px color-mix(in srgb, var(--pack-color) 10%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.84);
-}
-
-.packTile::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.72), transparent 44%),
-    linear-gradient(90deg, color-mix(in srgb, var(--pack-color) 8%, transparent), transparent 46%);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.72),
-    inset 0 -1px 0 color-mix(in srgb, var(--pack-color) 10%, transparent);
-  border-radius: inherit;
+  box-shadow: var(--shadow-card);
 }
 
 .packIconBand {
@@ -978,9 +958,7 @@
   height: 76px;
   margin: 0 -18px 16px;
   padding: 16px 18px;
-  background:
-    radial-gradient(circle at 24px 20px, color-mix(in srgb, var(--pack-color) 18%, transparent), transparent 44px),
-    linear-gradient(180deg, color-mix(in srgb, var(--pack-color) 9%, #fff), rgba(255, 255, 255, 0));
+  background: color-mix(in srgb, var(--pack-color) 8%, #fff);
 }
 
 .packIconBand::after {
@@ -1001,14 +979,12 @@
   width: 52px;
   height: 52px;
   margin-bottom: 0;
-  border: 2px solid;
+  border: 1px solid #E9E2D3;
   border-radius: 16px;
   flex-shrink: 0;
   overflow: hidden;
   z-index: 1;
-  box-shadow:
-    0 8px 18px color-mix(in srgb, var(--pack-color) 30%, transparent),
-    inset 0 1px 0 rgba(255, 255, 255, 0.32);
+  background: color-mix(in srgb, var(--pack-color) 16%, #fff);
 }
 
 .packIconWrap::after {
@@ -1024,7 +1000,6 @@
   z-index: 1;
   width: 30px;
   height: 30px;
-  filter: brightness(0) invert(1);
 }
 
 .packLabel {
@@ -1037,7 +1012,7 @@
 
 .packDesc {
   margin: 0;
-  color: rgba(22, 24, 35, 0.66);
+  color: var(--ink-soft);
   font-size: 12.5px;
   font-weight: 550;
   line-height: 1.5;
@@ -1051,13 +1026,14 @@
   min-height: 24px;
   padding: 0 9px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--pack-color) 12%, #FFFFFF);
+  background: #FAF3E6;
+  color: var(--ink-soft);
   margin-top: 12px;
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  border: 1px solid color-mix(in srgb, var(--pack-color) 28%, rgba(23, 23, 56, 0.08));
+  border: 1px solid #E9E2D3;
 }
 
 /* ─── AI / Use where you are ─────────────────────────── */

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -295,16 +295,15 @@
   width: 290px;
   /* iPhone proportions: 390 × 844 logical pixels */
   aspect-ratio: 390 / 844;
-  background: #1A1A1E;
+  background: #EFE7D6;
   border-radius: 46px;
   border: 1.5px solid rgba(210, 210, 220, 0.20);
   transform: translateX(-54%);
   overflow: hidden;
   box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.07),
-    0 48px 96px rgba(23, 23, 56, 0.28),
-    0 20px 40px rgba(23, 23, 56, 0.14),
-    0 4px 10px rgba(23, 23, 56, 0.08);
+    0 48px 96px rgba(38, 33, 62, 0.28),
+    0 20px 40px rgba(38, 33, 62, 0.14),
+    0 4px 10px rgba(38, 33, 62, 0.08);
 }
 
 /* Dynamic island pill — renders on top of screenshot */
@@ -315,7 +314,7 @@
   transform: translateX(-50%);
   width: 33%;
   height: 27px;
-  background: #0c0c10;
+  background: #26213E;
   border-radius: 14px;
   z-index: 10;
   pointer-events: none;
@@ -330,7 +329,7 @@
   bottom: 8px;
   border-radius: 39px;
   overflow: hidden;
-  background: #050508;
+  background: #FFFFFF;
 }
 
 .heroPhoneScreenshot {
@@ -347,20 +346,8 @@
   display: flex;
   flex-direction: column;
   padding: 58px 18px 18px;
-  background:
-    linear-gradient(180deg, rgba(38, 31, 86, 0.98) 0%, #171738 46%, #101024 100%);
-  color: #fff;
-}
-
-.heroPhoneResult::before {
-  content: "";
-  position: absolute;
-  inset: 128px 0 auto;
-  height: 220px;
-  background: linear-gradient(90deg, rgba(212, 103, 255, 0.16), rgba(213, 247, 78, 0.08), rgba(96, 179, 215, 0.14));
-  filter: blur(32px);
-  opacity: 0.65;
-  pointer-events: none;
+  background: #FFFFFF;
+  color: #26213E;
 }
 
 .heroResultTop,
@@ -390,26 +377,26 @@
   display: inline-flex;
   align-items: center;
   min-height: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid #E9E2D3;
   border-radius: 999px;
   padding: 0 10px;
-  background: rgba(255, 255, 255, 0.07);
+  background: #FAF3E6;
   font-size: 10px;
   font-weight: 800;
   letter-spacing: 0;
 }
 
 .heroResultPill {
-  color: var(--lime);
+  color: #26213E;
 }
 
 .heroResultFresh {
-  color: rgba(255, 255, 255, 0.68);
+  color: rgba(38, 33, 62, 0.62);
 }
 
 .heroResultKicker {
   margin: 0 0 8px;
-  color: rgba(255, 255, 255, 0.62);
+  color: rgba(38, 33, 62, 0.5);
   font-size: 10px;
   font-weight: 850;
   letter-spacing: 0.08em;
@@ -419,7 +406,7 @@
 
 .heroResultTitle {
   margin: 0;
-  color: #fff;
+  color: #26213E;
   font-size: 25px;
   font-weight: 900;
   letter-spacing: 0;
@@ -428,7 +415,7 @@
 
 .heroResultRequest {
   margin: 12px 0 12px;
-  color: rgba(255, 255, 255, 0.72);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 12px;
   font-weight: 600;
   line-height: 1.45;
@@ -437,7 +424,16 @@
 .heroResultReceipt {
   align-self: flex-start;
   margin-bottom: 14px;
-  color: var(--lime);
+  color: #26213E;
+}
+
+.heroResultReceipt::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  margin-right: 6px;
+  border-radius: 999px;
+  background: #93B32A;
 }
 
 .heroResultList {
@@ -450,21 +446,21 @@
   display: flex;
   flex-direction: column;
   gap: 3px;
-  border: 1px solid rgba(255, 255, 255, 0.10);
+  border: 1px solid #E9E2D3;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.075);
+  background: #FAF3E6;
   padding: 10px 11px;
 }
 
 .heroResultItem strong {
-  color: #fff;
+  color: #26213E;
   font-size: 13px;
   font-weight: 850;
   line-height: 1.15;
 }
 
 .heroResultItem span {
-  color: rgba(255, 255, 255, 0.66);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10.5px;
   font-weight: 600;
   line-height: 1.35;
@@ -472,7 +468,7 @@
 
 .heroResultNote {
   margin: 12px 0 10px;
-  color: rgba(255, 255, 255, 0.52);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10.5px;
   font-weight: 650;
   line-height: 1.35;
@@ -491,14 +487,14 @@
 
 .heroResultCta {
   min-height: 42px;
-  background: var(--lime);
-  color: var(--ink);
+  background: #26213E;
+  color: #FCF8F1;
   font-size: 14px;
 }
 
 .heroResultSecondary {
   min-height: 34px;
-  color: rgba(255, 255, 255, 0.58);
+  color: rgba(38, 33, 62, 0.55);
   font-size: 12px;
 }
 
@@ -511,12 +507,9 @@
   aspect-ratio: 1;
   overflow: hidden;
   border-radius: 18px;
-  background: #171738;
-  border: 3px solid rgba(96, 179, 215, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(96, 179, 215, 0.22);
+  background: #FFFFFF;
+  border: 1px solid #E9E2D3;
+  box-shadow: var(--shadow-card);
   padding: 0;
   isolation: isolate;
 }
@@ -526,26 +519,8 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  background:
-    linear-gradient(180deg, rgba(8, 8, 24, 0.02) 0%, rgba(8, 8, 24, 0.12) 42%, rgba(8, 8, 24, 0.78) 100%),
-    linear-gradient(90deg, rgba(8, 8, 24, 0.18) 0%, rgba(8, 8, 24, 0.00) 58%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 42%, rgba(255, 255, 255, 0.88) 100%);
   pointer-events: none;
-}
-
-.floatCardMusic {
-  border-color: rgba(212, 103, 255, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(212, 103, 255, 0.24);
-}
-
-.floatCardThree {
-  border-color: rgba(213, 247, 78, 0.92);
-  box-shadow:
-    0 18px 44px rgba(23, 23, 56, 0.18),
-    0 0 0 1px rgba(255, 255, 255, 0.20) inset,
-    0 0 24px rgba(213, 247, 78, 0.22);
 }
 
 .floatText {
@@ -558,7 +533,7 @@
 
 .floatCardLabel {
   margin: 0 0 5px;
-  color: rgba(255, 255, 255, 0.74);
+  color: rgba(38, 33, 62, 0.6);
   font-size: 10px;
   font-weight: 800;
   line-height: 1;
@@ -569,11 +544,10 @@
 .floatCardTitle {
   max-width: 164px;
   margin: 0;
-  color: #fff;
+  color: #26213E;
   font-size: 17px;
   font-weight: 900;
   line-height: 1.1;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.34);
 }
 
 .floatImage {
@@ -597,9 +571,9 @@
   width: 34px;
   height: 34px;
   border-radius: 999px;
-  background: var(--lime);
-  color: var(--ink);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  background: #26213E;
+  color: #FCF8F1;
+  box-shadow: 0 2px 8px rgba(38, 33, 62, 0.18);
 }
 
 .floatCheckIcon {
@@ -870,17 +844,16 @@
   position: relative;
   width: 150px;
   aspect-ratio: 390 / 844;
-  background: #1A1A1E;
+  background: #EFE7D6;
   border-radius: 26px;
   border: 1.5px solid rgba(210, 210, 220, 0.18);
   overflow: hidden;
   transform: rotate(4deg);
   transform-origin: 50% 60%;
   box-shadow:
-    inset 0 0 0 0.5px rgba(255, 255, 255, 0.08),
-    0 40px 80px rgba(23, 23, 56, 0.36),
-    0 16px 32px rgba(23, 23, 56, 0.20),
-    0 4px 10px rgba(23, 23, 56, 0.08);
+    0 40px 80px rgba(38, 33, 62, 0.36),
+    0 16px 32px rgba(38, 33, 62, 0.20),
+    0 4px 10px rgba(38, 33, 62, 0.08);
 }
 
 .howPackPhoneScreen {
@@ -891,7 +864,7 @@
   bottom: 5px;
   border-radius: 21px;
   overflow: hidden;
-  background: #050508;
+  background: #FFFFFF;
 }
 
 .howPackPhoneScreenshot {
@@ -910,7 +883,7 @@
   transform: translateX(-50%);
   width: 32%;
   height: 15px;
-  background: #0c0c10;
+  background: #26213E;
   border-radius: 8px;
   z-index: 5;
   pointer-events: none;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -139,7 +139,7 @@ function HeroPhone() {
       <div className={styles.heroPhoneScreenSlot}>
         <Image
           src="/brand/era2/hero-intori-music-pack-ready.jpg"
-          alt="intori music pack ready screen"
+          alt="intori Today's Food result on the web app"
           width={1206}
           height={2622}
           className={styles.heroPhoneScreenshot}
@@ -200,7 +200,7 @@ export default function HomePage() {
     <>
       <SeoHead
         title="intori - Made for you. Within minutes."
-        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App."
+        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App."
         canonicalPath="/"
         ogDescription="Answer a little. Get a useful first pass that already knows what matters to you."
         ogImageAlt="intori preview with personalized app signals"
@@ -221,7 +221,7 @@ export default function HomePage() {
                     Made for you.<br />Within minutes.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer a few quick questions and intori gives you a useful first pass — for food, game day, live music, and style — then go deeper in a quick chat. On the web and in World App.
+                    Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App.
                   </p>
                   <div className={styles.heroCtas}>
                     <a
@@ -263,7 +263,7 @@ export default function HomePage() {
                         className={styles.worldBadge}
                       />
                       <p className={styles.trustCopy}>
-                        Already used by <strong>5,500+</strong> verified humans on World
+                        Already used by <strong>6,655+</strong> verified humans on World
                       </p>
                     </div>
                   </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -105,34 +105,6 @@ function WorldIcon({ size = 18 }: { size?: number }) {
   )
 }
 
-// ChatGPT logo
-function ChatGPTLogo() {
-  return (
-    <svg className={styles.toolLogo} viewBox="0 0 24 24" fill="currentColor" aria-label="ChatGPT">
-      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zm-9.022 12.608a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855-5.815-3.354 2.02-1.168a.075.075 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.43-.696zm2.01-3.023-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365 2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z"/>
-    </svg>
-  )
-}
-
-// Claude / Anthropic logo
-function ClaudeLogo() {
-  return (
-    <svg className={styles.toolLogo} viewBox="0 0 46 32" fill="currentColor" aria-label="Claude">
-      <path d="M32.73 0h-6.945L38.45 32h6.945L32.73 0zM13.055 0 0 32h7.133l2.66-7.222h13.397l2.66 7.222h7.133L19.888 0h-6.833zm-1.205 19.487 4.62-12.56 4.619 12.56H11.85z"/>
-    </svg>
-  )
-}
-
-// Gemini logo
-function GeminiLogo() {
-  return (
-    <svg className={styles.toolLogo} viewBox="0 0 28 28" fill="currentColor" aria-label="Gemini">
-      <path d="M14 28A14 14 0 0 1 14 0a14.01 14.01 0 0 1 0 28zm0-3.5c5.8 0 10.5-4.7 10.5-10.5S19.8 3.5 14 3.5 3.5 8.2 3.5 14 8.2 24.5 14 24.5z" opacity=".2"/>
-      <path d="M14 0c0 7.73-6.27 14-14 14 7.73 0 14 6.27 14 14 0-7.73 6.27-14 14-14-7.73 0-14-6.27-14-14z"/>
-    </svg>
-  )
-}
-
 function HeroPhone() {
   return (
     <div className={styles.heroPhoneShell}>
@@ -391,24 +363,19 @@ export default function HomePage() {
             <div className={styles.container}>
               <div className={styles.aiInner}>
                 <div className={styles.aiText}>
-                  <h2 className={styles.aiHeading}>Continue in ChatGPT, Claude, Gemini, or your trusted AI tool</h2>
+                  <h2 className={styles.aiHeading}>A warm welcome, then picks made for you</h2>
                   <p className={styles.aiBody}>
-                    intori gives you a focused starting point. Take it further wherever you already work with AI.
+                    Each helper opens with a friendly hello, gives you a first pass shaped by your answers,
+                    and lets you see more when you want it.
                   </p>
+                  <a href={APP_URL} className={styles.ctaPrimary} target="_blank" rel="noopener noreferrer">
+                    Meet a helper
+                  </a>
                 </div>
-                <div className={styles.toolPills}>
-                  <span className={styles.toolPill}>
-                    <ChatGPTLogo />
-                    ChatGPT
-                  </span>
-                  <span className={styles.toolPill}>
-                    <ClaudeLogo />
-                    Claude
-                  </span>
-                  <span className={styles.toolPill}>
-                    <GeminiLogo />
-                    Gemini
-                  </span>
+                <div className={styles.helperPeek} aria-hidden="true">
+                  <p className={styles.peekBubble}>Hi! Here&rsquo;s tonight&rsquo;s dinner, made for you.</p>
+                  <p className={styles.peekResult}>Thai basil chicken · 20 min</p>
+                  <span className={styles.peekMore}>See more picks &rarr;</span>
                 </div>
               </div>
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,7 +36,7 @@ const PACKS = [
     label: 'Knows when to ask more',
     desc: 'When it needs more context, intori asks one focused question instead of guessing.',
     badge: 'No guessing',
-    color: '#60B3D7',
+    color: '#D467FF',
   },
   {
     icon: '/brand/icons/sports_fans.svg',
@@ -57,14 +57,14 @@ const PACKS = [
     label: 'Fresh where it matters',
     desc: 'Music, sports, food, and plans can include source and freshness notes.',
     badge: 'Fresh context',
-    color: '#60B3D7',
+    color: '#F76B15',
   },
   {
-    icon: '/brand/icons/travel_enthusiasts.svg',
-    label: 'Easy to continue',
-    desc: 'Take the first pass into ChatGPT, Claude, Gemini, or a trusted app.',
-    badge: 'Continue',
-    color: '#60B3D7',
+    icon: '/brand/icons/casual_socializers.svg',
+    label: 'See more, in-app',
+    desc: 'Each helper opens with a warm intro, shows picks made for you, and lets you look further.',
+    badge: 'See more',
+    color: '#FF5C8A',
   },
 ]
 
@@ -72,7 +72,7 @@ const HOW_STEPS = [
   {
     number: "1",
     title: "Choose where to start.",
-    body: "Start with food, game day, live music, or style — the daily helpers intori personalizes for you.",
+    body: "Start with food, game day, live music, or style, the daily helpers intori personalizes for you.",
     visual: "packs",
   },
   {
@@ -84,7 +84,7 @@ const HOW_STEPS = [
   {
     number: "3",
     title: "Get picks made for you.",
-    body: "Run intori for food picks, game-day options, live-music ideas, and style finds — then go deeper in a quick chat.",
+    body: "Run intori for food picks, game-day plans, live-music ideas, and style finds, then see more in a quick chat inside intori.",
     visual: "tools",
   },
 ]
@@ -178,10 +178,9 @@ function HowVisual({ type }: { type: string }) {
 
   if (type === "tools") {
     return (
-      <div className={styles.toolMiniRow} aria-hidden="true">
-        <span className={styles.toolMini}><ChatGPTLogo /></span>
-        <span className={styles.toolMini}><ClaudeLogo /></span>
-        <span className={styles.toolMini}><GeminiLogo /></span>
+      <div className={styles.seeMoreMini} aria-hidden="true">
+        <span className={styles.seeMoreBubble}>Here&rsquo;s your first pass</span>
+        <span className={styles.seeMoreChip}>See more &rarr;</span>
       </div>
     )
   }
@@ -363,7 +362,7 @@ export default function HomePage() {
             </div>
           </section>
 
-          <section id="packs" className={styles.packsSection}>
+          <section id="why" className={styles.packsSection}>
             <div className={styles.container}>
               <h2 className={styles.sectionHeading}>Why intori gets more useful</h2>
               <p className={styles.packsSub}>Your answers teach intori what matters, when to ask for more, and how to explain the first pass it gives you.</p>
@@ -375,20 +374,13 @@ export default function HomePage() {
                     style={{ '--pack-color': pack.color } as CSSProperties}
                   >
                     <div className={styles.packIconBand}>
-                      <div
-                        className={styles.packIconWrap}
-                        style={{
-                          background: pack.color,
-                          borderColor: `${pack.color}f0`,
-                          boxShadow: `0 0 22px ${pack.color}66`,
-                        }}
-                      >
+                      <div className={styles.packIconWrap}>
                         <Image src={pack.icon} alt="" width={34} height={34} className={styles.packIcon} />
                       </div>
                     </div>
                     <p className={styles.packLabel}>{pack.label}</p>
                     <p className={styles.packDesc}>{pack.desc}</p>
-                    <span className={styles.packCluster} style={{ color: pack.color }}>{pack.badge}</span>
+                    <span className={styles.packCluster}>{pack.badge}</span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## PR4 — AI section rebuild + Dev bridge + component deletion

Replaces the "continue in ChatGPT/Claude/Gemini" section with honest in-app "see more" messaging, warms the developer bridge, and deletes the now-unused AI-tool logo components. **Stacked on PR3** (base = `warm/03-how-why`).

Follows `docs/internal/warm-polish-build-plan-2026-07-08.md` §PR4.

### `pages/index.tsx`
- **Rebuilt the AI section:** "A warm welcome, then picks made for you" + a first-pass body + an ink **"Meet a helper"** CTA + a warm helper-peek mock (greeting bubble → "Thai basil chicken · 20 min" → "See more picks →"). No copy implying rich back-and-forth steering (we don't have that yet).
- **Deleted `ChatGPTLogo` / `ClaudeLogo` / `GeminiLogo`** — unreferenced after the PR3 step-3 change + this section rebuild. This is exactly the `no-unused-vars` failure that broke the build in `c28d78b`; **`npm run lint` is clean.**

### `pages/index.module.css`
- Deleted `.toolPills` / `.toolPill` / `.toolLogo`; added `.helperPeek` / `.peekBubble` / `.peekResult` / `.peekMore`.
- **Dev bridge → cream editorial card:** navy gradient + blue/lime radials + inset-white glows → `linear-gradient(135deg,#FFFFFF,#F3ECDD)`, `#EAD9C8` border, `var(--shadow-card)`, ink text. Flow cards → white/`#EAD9C8`; `strong`/spans → ink/ink-soft; `checkLine` ink; check chip → ink bg + cream check; dev arrow ink; **code color → ink `#26213E`** (not `#93B32A`, which fails AA on this light card).
- Removed the now-unreferenced **`--lime` / `--dark-bg` / `--dark-mid`** temp tokens from the `.page` block.

### Milestone
`pages/index.module.css` is now **fully free of crypto DNA** — no neon/dark/blue hexes, no `0 0 Npx` glows, no legacy tokens (verified by grep). The whole homepage renders warm.

### Verification
- `npm run lint` → clean (no `no-unused-vars`).
- Logged-out local render: AI section reads "A warm welcome…" with the warm peek mock + ink CTA, no third-party logos; dev bridge is a cream card with ink text/code, ink check chips, no navy, no glow.
- Greps: `index.module.css` clean of `#D5F74E/#171738/#1F1F43/#60B3D7/#9664FA`, glow pattern, and `var(--lime|--dark-*)`; `index.tsx` clean of `ChatGPTLogo/ClaudeLogo/GeminiLogo/toolPill/"Continue in ChatGPT"`.

> Stacked-PR series — re-target to `helper-launch/web-primary-v2` on merge, after PR1→PR3. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
