### PR TITLE
PR5 — FAQ + copy + SEO

### DIFF
--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -8,15 +8,15 @@ export const FAQ: FaqItem[] = [
   {
     question: "What is intori?",
     answer: [
-      "intori helps you get useful personalized recommendations, plans, and drafts without starting from scratch every time.",
-      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape food picks, game-day options, live-music ideas, style finds, and more around you."
+      "intori gives you personalized recommendations and plans without starting from scratch every time.",
+      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape your food picks, game-day plans, live-music ideas, and style finds around you."
     ]
   },
   {
     question: "Why would I use intori instead of just asking AI myself?",
     answer: [
       "Because repeating yourself gets old.",
-      "Your taste, preferences, pace, budget, interests, and boundaries should not have to be explained again every time you use a new AI tool. intori helps you build that once, then use it wherever you want a more personal starting point."
+      "Your taste, budget, pace, and boundaries should not have to be explained from scratch every time you want a recommendation. intori learns them once and uses them across every helper, so each result already starts closer to you."
     ]
   },
   {
@@ -44,21 +44,21 @@ export const FAQ: FaqItem[] = [
     question: "What can intori do right now?",
     answer: [
       "Four daily helpers are live: Today's Food, Game Day, live-music ideas, and Style Finds.",
-      "Each gives you a useful first pass that fits your taste, timing, and constraints — and you can go deeper in a quick chat when you want more."
+      "Each gives you a useful first pass that fits your taste, timing, and constraints, and you can go deeper in a quick chat inside intori whenever you want more."
     ]
   },
   {
     question: "How is intori different from ChatGPT, Claude, or Gemini?",
     answer: [
-      "ChatGPT, Claude, and Gemini are great places to keep working.",
-      "intori helps with the part before that: remembering what matters to you and getting the first personalized request started. After that, you can continue in the AI tool you already use."
+      "General AI tools start you at a blank box and wait for you to explain what you want.",
+      "intori already remembers what matters to you and does the first pass for you, so you get useful food picks, game-day plans, live-music ideas, and style finds without setting the scene every time. When you want more, you go deeper in a quick chat right inside intori."
     ]
   },
   {
     question: "Will I have to keep answering the same questions?",
     answer: [
-      "No, that is one of the main problems intori is trying to solve.",
-      "Like filling out the same form over and over, repeating your preferences to every AI tool is annoying. intori helps you carry what you have already shared into future recommendations, plans, and drafts."
+      "No. That is one of the main problems intori is built to solve.",
+      "Repeating your preferences over and over is tiring. intori carries what you have already shared into every helper, so your answers keep making future recommendations and plans better instead of starting over."
     ]
   },
   {
@@ -71,15 +71,15 @@ export const FAQ: FaqItem[] = [
   {
     question: "Where can I use intori?",
     answer: [
-      "intori is on the web at app.intori.co — just sign in to get started.",
-      "It is also in the World App, where it is already used by thousands of verified humans."
+      "intori is on the web at app.intori.co. Just sign in to get started.",
+      "It is also in the World App, where it is already used by more than 6,655 verified humans."
     ]
   },
   {
     question: "Why does intori mention verified humans?",
     answer: [
       "World ID gives intori a verified-human trust layer and lets your personalization carry across the web and the World App.",
-      "It helps keep access fair and reduce abuse, but it is not a gate — anyone can use intori on the web."
+      "It helps keep access fair and reduce abuse, but it is not a gate. Anyone can use intori on the web."
     ]
   },
   {

--- a/lib/seo.tsx
+++ b/lib/seo.tsx
@@ -4,7 +4,7 @@ export const SITE_URL = 'https://www.intori.co'
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/og/og-default.jpg`
 export const DEFAULT_TITLE = 'intori - Made for you. Within minutes.'
 export const DEFAULT_DESCRIPTION =
-  'Choose where to start, answer a few quick questions, and intori shapes personalized recommendations, plans, drafts, and more around you.'
+  'Choose where to start, answer a few quick questions, and intori shapes personalized food picks, game-day plans, live-music ideas, and style finds around you.'
 export const DEFAULT_SOCIAL_DESCRIPTION =
   'Choose where to start, answer quick questions, and intori gives you a more personal starting point.'
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,7 +30,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width, viewport-fit=cover"
         />
-        <meta name="keywords" content="intori, World, personalization, music ideas, game day ideas, time planning, drafts"/>
+        <meta name="keywords" content="intori, World, personalization, food ideas, game day, live music, style finds"/>
         <meta name="author" content="Tuum Tech"/>
       </Head>
       <SeoHead canonicalPath="/" />

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -10,7 +10,7 @@ const FaqPage: NextPage = () => {
     <>
       <SeoHead
         title="FAQ - intori"
-        description="Questions about intori, personalization, World, Credits, and continuing in your favorite AI tool."
+        description="Questions about intori, personalization, World, Credits, and going deeper inside the app."
         canonicalPath="/faq"
         ogImageAlt="intori FAQ preview"
       />

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1331,7 +1331,7 @@
   width: 28px;
   height: 28px;
   border-radius: 999px;
-  background: rgba(213, 247, 78, 0.34);
+  background: #FAF3E6;
   color: var(--ink);
   font-size: 18px;
   font-weight: 900;


### PR DESCRIPTION
## PR5 — FAQ + copy + SEO

Warms the FAQ toggle and rewrites the FAQ answers + SEO defaults to the honest in-app "see more" story (no export-to-AI framing, no drafts/time-planning). **Stacked on PR4** (base = `warm/04-ai-dev`). Text-only, low risk.

Follows `docs/internal/warm-polish-build-plan-2026-07-08.md` §PR5.

### Changes
- **`index.module.css`** — `.faqQuestion::after` toggle `rgba(213,247,78,.34)` → `#FAF3E6` (ink glyph unchanged). This was the last `rgba(213,247,78…)` lime in the file.
- **`lib/faq.ts`** — rewrote the 7 answers per spec §5b: *What is intori* · *Why use intori vs asking AI* · *What can intori do right now* · *How is intori different from ChatGPT/Claude/Gemini* (kills the export framing) · *Will I have to keep answering* · *Where can I use intori* (now "more than 6,655") · *Why verified humans*. Removed em dashes and "drafts"/external-AI-export copy from those answers.
- **`faq.tsx`** — meta description "…continuing in your favorite AI tool" → "…going deeper inside the app."
- **`_app.tsx`** — keywords "time planning, drafts" → "food ideas, game day, live music, style finds".
- **`seo.tsx`** — `DEFAULT_DESCRIPTION` dropped "drafts"; aligned to the four helpers.

### Notes / flags
- **Guardrail #7 vs §5b (flagging as instructed):** guardrail #7 says don't touch the faq.ts line with "go deeper in a quick chat when you want more" (it's already correct), but §5b's rewrite for *What can intori do right now?* changes that exact line to remove its em dash and add "inside intori" → "…constraints, and you can go deeper in a quick chat inside intori whenever you want more." Since the current line has an em dash (which guardrail #6 forbids) and §5b is the spec's explicit final text for this answer — and it **preserves** the "go deeper in a quick chat" messaging — I applied §5b. Net: guardrail #7's intent (keep the good in-app copy) is honored and the em dash is gone.
- The comparison **question** "How is intori different from ChatGPT, Claude, or Gemini?" is intentionally kept (real user question); only its answer changed. So the Appendix-A `ChatGPT|Claude|Gemini` grep will still match this one question in `lib/faq.ts` — expected, not stale export framing.

### Verification
- `npm run lint` → clean.
- Logged-out `/faq`: toggle computed `#FAF3E6` bg + `#26213E` glyph; rewritten answers render; no em dashes in `faq.ts`; "6,655" present; no "drafts"/"time planning" in `_app.tsx`/`seo.tsx`; no `rgba(213,247,78…)` left in `index.module.css`.

> Stacked-PR series — re-target to `helper-launch/web-primary-v2` on merge, after PR1→PR4. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
