### PR TITLE
Republish the three news articles

### DIFF
--- a/content/news/intori-now-live-on-world.md
+++ b/content/news/intori-now-live-on-world.md
@@ -5,7 +5,6 @@ date: "2026-02-26"
 author: "Donald Bullers"
 slug: "intori-now-live-on-world"
 heroImage: "/news/intori-world-01.png"
-published: false
 tags:
   - "World"
   - "Identity"

--- a/content/news/introducing-scis.md
+++ b/content/news/introducing-scis.md
@@ -5,7 +5,6 @@ date: "2026-04-17"
 author: "Donald Bullers"
 slug: "introducing-scis"
 heroImage: "/news/intori-scis-01.png"
-published: false
 tags:
   - "Product"
   - "Infrastructure"

--- a/content/news/packs-build-your-identity.md
+++ b/content/news/packs-build-your-identity.md
@@ -5,7 +5,6 @@ date: "2026-03-24"
 author: "Donald Bullers"
 slug: "packs-build-your-identity"
 heroImage: "/news/intori-packs-01.png"
-published: false
 tags:
   - "Product"
   - "Packs"


### PR DESCRIPTION
Brings the news articles back to the live site — reverses the launch-time unpublish.

- Removes `published: false` from `packs-build-your-identity`, `introducing-scis`, and `intori-now-live-on-world`.
- They return to the `/news` index, the sitemap, and their `/news/[slug]` routes; the "More soon." empty state goes away.

**Note:** post *content* is unchanged — still the original Packs/Stamps/SCIS narrative (deks feed OG/social meta). The pages render in the warm reskin styling. Post thumbnail art is the articles' own images (a couple are dark). Say the word if you want the copy/art warmed up in a follow-up.

Verified logged-out locally: `/news` lists all three; no "More soon.".

🤖 Generated with [Claude Code](https://claude.com/claude-code)