### PR TITLE
Hero + how-it-works + AI polish

### DIFF
--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -72,7 +72,7 @@ export const FAQ: FaqItem[] = [
     question: "Where can I use intori?",
     answer: [
       "intori is on the web at app.intori.co. Just sign in to get started.",
-      "It is also in the World App, where it is already used by more than 6,655 verified humans."
+      "It is also in the World App, where it is already used by more than 6,500 verified humans."
     ]
   },
   {

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -301,20 +301,6 @@
     0 4px 10px rgba(38, 33, 62, 0.08);
 }
 
-/* Dynamic island pill — renders on top of screenshot */
-.heroPhoneDynamicIsland {
-  position: absolute;
-  top: 14px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 33%;
-  height: 27px;
-  background: #26213E;
-  border-radius: 14px;
-  z-index: 10;
-  pointer-events: none;
-}
-
 /* Screen inset — uniform 8px bezel inside shell */
 .heroPhoneScreenSlot {
   position: absolute;
@@ -514,7 +500,7 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 42%, rgba(255, 255, 255, 0.88) 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 20%, rgba(255, 255, 255, 0.8) 50%, rgba(255, 255, 255, 0.98) 100%);
   pointer-events: none;
 }
 
@@ -528,12 +514,13 @@
 
 .floatCardLabel {
   margin: 0 0 5px;
-  color: rgba(38, 33, 62, 0.6);
+  color: rgba(38, 33, 62, 0.78);
   font-size: 10px;
-  font-weight: 800;
+  font-weight: 850;
   line-height: 1;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.85);
 }
 
 .floatCardTitle {
@@ -543,6 +530,7 @@
   font-size: 17px;
   font-weight: 900;
   line-height: 1.1;
+  text-shadow: 0 1px 3px rgba(255, 255, 255, 0.9);
 }
 
 .floatImage {
@@ -587,7 +575,7 @@
 }
 
 .floatCardWeekend {
-  left: -18px;
+  left: -48px;
   top: 42px;
 }
 
@@ -861,19 +849,7 @@
   object-position: center 3%;
 }
 
-/* Dynamic island — proportional to 165px shell */
-.howPackPhoneIsland {
-  position: absolute;
-  top: 8px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 32%;
-  height: 15px;
-  background: #26213E;
-  border-radius: 8px;
-  z-index: 5;
-  pointer-events: none;
-}
+/* (dynamic-island overlay removed — the app screenshots include the real notch) */
 
 /* Step 3 "see more" mini */
 
@@ -1072,50 +1048,27 @@
 }
 
 .helperPeek {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 8px;
-  background: linear-gradient(180deg, #FFFFFF, #FAF3E6);
-  border: 1px solid #E9E2D3;
-  border-radius: var(--radius-card);
-  padding: 22px;
-  box-shadow: var(--shadow-card);
+  width: 288px;
+  max-width: 100%;
+  margin: 0 auto;
+  aspect-ratio: 390 / 844;
+  background: #EFE7D6;
+  border: 1.5px solid rgba(210, 210, 220, 0.28);
+  border-radius: 44px;
+  padding: 8px;
+  overflow: hidden;
+  box-shadow:
+    0 40px 80px rgba(38, 33, 62, 0.22),
+    0 16px 32px rgba(38, 33, 62, 0.14);
 }
 
-.peekBubble {
-  margin: 0;
-  background: #F3ECDD;
-  border-radius: 12px 12px 12px 4px;
-  padding: 9px 12px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #26213E;
-  max-width: 80%;
-}
-
-.peekResult {
-  margin: 0;
-  background: #FFFFFF;
-  border: 1px solid #E9E2D3;
-  border-radius: 10px;
-  padding: 9px 12px;
-  font-size: 14px;
-  font-weight: 800;
-  color: #26213E;
-}
-
-.peekMore {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: #FFFFFF;
-  border: 1px solid #E9E2D3;
-  border-radius: 999px;
-  padding: 7px 13px;
-  font-size: 12px;
-  font-weight: 800;
-  color: #26213E;
+.peekShot {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center top;
+  border-radius: 36px;
 }
 
 /* ─── Developer bridge ────────────────────────────────── */

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -134,7 +134,6 @@ function HowPackPhone() {
           className={styles.howPackPhoneScreenshot}
         />
       </div>
-      <div className={styles.howPackPhoneIsland} />
     </div>
   )
 }
@@ -234,7 +233,7 @@ export default function HomePage() {
                         className={styles.worldBadge}
                       />
                       <p className={styles.trustCopy}>
-                        Already used by <strong>6,655+</strong> verified humans on World
+                        Already used by <strong>6,500+</strong> verified humans on World
                       </p>
                     </div>
                   </div>
@@ -376,9 +375,13 @@ export default function HomePage() {
                   </a>
                 </div>
                 <div className={styles.helperPeek} aria-hidden="true">
-                  <p className={styles.peekBubble}>Hi! Here&rsquo;s tonight&rsquo;s dinner, made for you.</p>
-                  <p className={styles.peekResult}>Thai basil chicken · 20 min</p>
-                  <span className={styles.peekMore}>See more picks &rarr;</span>
+                  <Image
+                    src="/brand/warm/todays-food-result.jpg"
+                    alt=""
+                    width={820}
+                    height={1782}
+                    className={styles.peekShot}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Final polish round per feedback.

### Hero
- World user count `6,655+` → **`6,500+`** (cleaner rounded number; hero trust line + FAQ answer).
- Bumped the **Game Day** float card left (`-18px` → `-48px`) so it no longer covers "Good morning" on the phone screenshot.
- **Text legibility on all 3 float cards:** stronger white bottom scrim, darker/heavier label, and a white text-halo on label + title.

### How it works
- Removed the **dynamic-island overlay** on the step-1 phone — the real app screenshot already includes the iOS notch/status bar, so the plum pill was a redundant "blue rectangle." Top is now all black. Deleted the now-dead island CSS (both hero + how-pack).

### AI section
- Replaced the CSS peek mock with the real **Today's Food result** screenshot (`/brand/warm/todays-food-result.jpg`, one of the stored extras) in a warm phone frame — shows the actual "see more" flow.

Verified logged-out at mobile + desktop widths; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)