### PR TITLE
feat(hero): lead the homepage with the dinner outcome

### DIFF
--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -235,10 +235,6 @@
   gap: 8px;
 }
 
-.worldBadge {
-  flex-shrink: 0;
-  border-radius: 999px;
-}
 
 .trustCopy {
   margin: 0;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -170,10 +170,10 @@ export default function HomePage() {
     <>
       <SeoHead
         title="intori - Made for you. Within minutes."
-        description="Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App."
+        description="What's for dinner? intori hands you three picks for tonight — shaped by your household's tastes, in about 30 seconds. Game day, live music, and style come next. On the web and in World App."
         canonicalPath="/"
-        ogDescription="Answer a little. Get a useful first pass that already knows what matters to you."
-        ogImageAlt="intori preview with personalized app signals"
+        ogDescription="Three dinner picks for tonight, in about 30 seconds — built around your household's tastes."
+        ogImageAlt="intori preview showing tonight's dinner picks"
       />
 
       <div className={styles.page}>
@@ -186,12 +186,12 @@ export default function HomePage() {
               <div className={styles.heroGrid}>
 
                 <div className={styles.heroLeft}>
-                  <p className={styles.heroEyebrow}>Personalization, built from you</p>
+                  <p className={styles.heroEyebrow}>Tonight&rsquo;s dinner, sorted</p>
                   <h1 className={styles.heroHeadline}>
-                    Made for you.<br />Within minutes.
+                    Dinner,<br />decided.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer a few quick questions and intori gives you a useful first pass for food, game day, live music, and style, then a warm chat to see more. On the web and in World App.
+                    Answer a few quick questions and intori hands you three dinner picks for tonight &mdash; shaped by your household&rsquo;s tastes, in about 30 seconds. Game day, live music, and style come next, each learning as you go.
                   </p>
                   <div className={styles.heroCtas}>
                     <a
@@ -225,15 +225,8 @@ export default function HomePage() {
                       ))}
                     </div>
                     <div className={styles.trustRight}>
-                      <Image
-                        src="/brand/world/world-id-verification-badge.svg"
-                        alt="World ID verified"
-                        width={20}
-                        height={20}
-                        className={styles.worldBadge}
-                      />
                       <p className={styles.trustCopy}>
-                        Already used by <strong>6,500+</strong> verified humans on World
+                        Already used by <strong>6,500+</strong> people
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
## What

Swaps the above-the-fold homepage hero from co-equal-helper personalization to the **food wedge** — the locked millennial-parents direction (E2 in the build plan; the other traffic driver alongside the 4pm dinner push shipped in the app).

| | Before | After |
|---|---|---|
| Eyebrow | Personalization, built from you | Tonight's dinner, sorted |
| H1 | Made for you. Within minutes. | **Dinner, decided.** |
| Body | "useful first pass for food, game day, live music, and style" | Three dinner picks for tonight from your household's tastes in ~30s; game day, music, style follow in one line |
| Trust | Already used by **6,500+** verified humans on World (+ World ID badge) | Already used by **6,500+** people |

- The brand umbrella **"Made for you. Within minutes."** stays as the `<title>` / SEO brand line.
- SEO `description` + `ogDescription` realigned dinner-first.
- Trust row **de-cryptoed**: World ID badge and "verified humans on World" removed (the UX research flags this as the single most crypto-adjacent signal to parents). The real user count is kept — no fabricated "families" claim we can't back pre-GTM.

## Why

Food is the wedge; the homepage was the last surface still selling mechanism + four co-equal helpers to an audience the research says wants the outcome. Ink CTA retained (no neon-lime CTA — honors the warm-token guardrail).

## Review

Bugbot is at its usage cap (refills Jul 23), so this was reviewed by an independent adversarial agent — see the follow-up.

## Verification

`tsc --noEmit` and `next lint` both clean. Rendered logged-out on local dev (desktop + float cards) — screenshots on-message.

## Known follow-up (chipped separately)

The phone-mock screenshot assets still show the app's old "· uses 1 credit" copy (removed in app #1680). Re-shoot tracked as its own task; image-only, no layout impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)