### PR TITLE
content(positioning): carry the de-cryptoed framing past the hero

### DIFF
--- a/content/news/intori-now-live-on-world.md
+++ b/content/news/intori-now-live-on-world.md
@@ -5,6 +5,11 @@ date: "2026-02-26"
 author: "Donald Bullers"
 slug: "intori-now-live-on-world"
 heroImage: "/news/intori-world-01.png"
+# Unpublished 2026-07-19: the body is an accurate Feb 2026 record (including
+# third-party quotes) of the v1 stamps/social-discovery product and its
+# verified-human framing. Both are superseded. Kept verbatim rather than
+# rewritten so the quotes stay true to what was said; hidden from the site.
+published: false
 tags:
   - "World"
   - "Identity"

--- a/content/news/packs-build-your-identity.md
+++ b/content/news/packs-build-your-identity.md
@@ -11,7 +11,7 @@ tags:
   - "Identity"
 ---
 
-When we first announced the [launch of intori](https://www.intori.co/news/intori-now-live-on-world), every connection started the same way: one shared set of daily questions. It worked. People showed up, answered, and discovered others through those responses. But it also revealed a limitation. Identity is not one path. It is layered, contextual, and constantly evolving.
+When we first announced the launch of intori, every connection started the same way: one shared set of daily questions. It worked. People showed up, answered, and discovered others through those responses. But it also revealed a limitation. Identity is not one path. It is layered, contextual, and constantly evolving.
 
 So we rebuilt the system.
 

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -72,14 +72,8 @@ export const FAQ: FaqItem[] = [
     question: "Where can I use intori?",
     answer: [
       "intori is on the web at app.intori.co. Just sign in to get started.",
-      "It is also in the World App, where it is already used by more than 6,500 verified humans."
-    ]
-  },
-  {
-    question: "Why does intori mention verified humans?",
-    answer: [
-      "World ID gives intori a verified-human trust layer and lets your personalization carry across the web and the World App.",
-      "It helps keep access fair and reduce abuse, but it is not a gate. Anyone can use intori on the web."
+      "It is also in the World App, where it is already used by more than 6,500 people.",
+      "Your answers carry across both, so whichever one you open, intori already knows you."
     ]
   },
   {

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,19 @@ const nextConfig = {
   swcMinify: true,
   images: {
     unoptimized: true
+  },
+  async redirects() {
+    return [
+      {
+        // The Feb 2026 World launch announcement was unpublished on 2026-07-19.
+        // It had external press distribution, so send those inbound links to the
+        // news index rather than a dead end. Temporary (307) on purpose: the post
+        // is hidden, not retired, and may be restored.
+        source: '/news/intori-now-live-on-world',
+        destination: '/news',
+        permanent: false
+      }
+    ]
   }
 }
 

--- a/pages/news/[slug].tsx
+++ b/pages/news/[slug].tsx
@@ -2,12 +2,9 @@ import type { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'ne
 import Head from 'next/head'
 import { MarketingFooter, MarketingHeader, WorldIcon } from '@/components/MarketingChrome'
 import { getAllSlugs, getPostBySlug, type Post } from '@/lib/news'
-import { SeoHead, SITE_URL, absoluteUrl } from '@/lib/seo'
+import { SeoHead, absoluteUrl } from '@/lib/seo'
 import { APP_URL, WORLD_APP_URL } from '@/lib/appLinks'
 import styles from './news.module.css'
-
-const LAUNCH_ARTICLE_SLUG = 'intori-now-live-on-world'
-const LAUNCH_OG_IMAGE = `${SITE_URL}/news/intori-world-01.png`
 
 type Props = {
   post: Post
@@ -44,11 +41,8 @@ function formatDate(dateStr: string) {
 export default function NewsPost({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const isLaunchArticle = post.slug === LAUNCH_ARTICLE_SLUG
   const pageTitle = `${post.title} - intori`
-  const ogImage = isLaunchArticle
-    ? LAUNCH_OG_IMAGE
-    : absoluteUrl(post.heroImage || '/og/og-default.jpg')
+  const ogImage = absoluteUrl(post.heroImage || '/og/og-default.jpg')
 
   return (
     <div className={styles.newsArticleWrapper}>


### PR DESCRIPTION
Follow-through on #193. That PR softened the homepage trust row to "used by 6,500+ people"; this carries the same decision to the two surfaces still on the old framing.

## FAQ — softened
- `lib/faq.ts` "Where can I use intori?" keeps the honest count, drops the qualifier: **"more than 6,500 verified humans" → "more than 6,500 people"**. No fabricated families/parents claim pre-GTM.
- Removed the dedicated **"Why does intori mention verified humans?"** Q. It existed to explain a hero claim #193 deleted, so it was orphaned. Its one durable idea — personalization carries across web and World App — moves up into the "Where" answer as a benefit line instead of a trust disclaimer.
- **World App stays** as a real place you can use intori. Only the crypto-verification framing is gone, not the distribution channel.

No JSON-LD/FAQ structured data consumes this file, so the edit is contained to `/faq`.

## News post — unpublished, not rewritten
`content/news/intori-now-live-on-world.md` gets `published: false`.

Rewriting it was the wrong tool: it's a dated Feb 2026 announcement carrying **attributed quotes from real third parties** (Shane Mac / XMTP Labs, Maria Gomez / World Foundation). Softening its language would put words in their mouths. It also describes the **retired v1 product** — stamps, social discovery, matching, tap-into-World-Chat — so it was stale on product grounds independent of tone. Unpublishing fixes both without touching a word, and is reversible.

Two things that fall out of it:
- **307 redirect** (`next.config.js`) to `/news`. The post had external press distribution, so inbound links shouldn't dead-end. Deliberately temporary, not 308 — the post is hidden, not retired.
- **De-linked** the inbound reference in `packs-build-your-identity.md`, which would otherwise point at a 404. Prose unchanged.

## Dead code
`pages/news/[slug].tsx` special-cased this slug for a custom OG image. `getStaticPaths` is `fallback: false`, so once the post is unpublished that branch is permanently unreachable — removed it plus the now-unused `SITE_URL` import. Same class of orphan Bugbot caught in #193.

## Verification
- `tsc --noEmit` clean, `next lint` clean.
- Production build emits only the two remaining news routes (`introducing-scis`, `packs-build-your-identity`).
- Served the build: `/faq` renders the new copy with no "verified human" anywhere; `/news` no longer lists the post; the old URL returns `307 → /news`.
- `grep` confirms no "verified human" remains on any live surface. Legal pages (`terms-of-use`, `privacy-policy`) still reference World App/World ID factually — untouched on purpose, since those are accuracy-governed, not positioning copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)