### PR TITLE
chore(copy): register fixes for hero, FAQ, meta; unpublish pre-pivot news

### DIFF
--- a/content/news/introducing-scis.md
+++ b/content/news/introducing-scis.md
@@ -5,6 +5,9 @@ date: "2026-04-17"
 author: "Donald Bullers"
 slug: "introducing-scis"
 heroImage: "/news/intori-scis-01.png"
+# Unpublished 2026-07-23: pre-pivot Packs/Stamps/Connections register in dek
+# and body. Historical record kept verbatim; hidden from the site.
+published: false
 tags:
   - "Product"
   - "Infrastructure"

--- a/content/news/packs-build-your-identity.md
+++ b/content/news/packs-build-your-identity.md
@@ -5,6 +5,9 @@ date: "2026-03-24"
 author: "Donald Bullers"
 slug: "packs-build-your-identity"
 heroImage: "/news/intori-packs-01.png"
+# Unpublished 2026-07-23: pre-pivot Packs/Stamps/matches/identity register.
+# Historical record kept verbatim; hidden from index, routes, and sitemap.
+published: false
 tags:
   - "Product"
   - "Packs"

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -9,11 +9,11 @@ export const FAQ: FaqItem[] = [
     question: "What is intori?",
     answer: [
       "intori gives you personalized recommendations and plans without starting from scratch every time.",
-      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape your food picks, game-day plans, live-music ideas, and style finds around you."
+      "Choose where to start, answer a few quick questions, and intori uses what it learns to shape your food picks, what to watch, game-day plans, live shows, and style finds around you."
     ]
   },
   {
-    question: "Why would I use intori instead of just asking AI myself?",
+    question: "Why not just search for this stuff myself?",
     answer: [
       "Because repeating yourself gets old.",
       "Your taste, budget, pace, and boundaries should not have to be explained from scratch every time you want a recommendation. intori learns them once and uses them across every helper, so each result already starts closer to you."
@@ -29,29 +29,29 @@ export const FAQ: FaqItem[] = [
   {
     question: "What can I start with?",
     answer: [
-      "intori starts with daily helpers like Today's Food, Game Day, live music, and Style Finds.",
+      "intori starts with five daily helpers: Today's Food, Watch Radar, Game Day, Music Events, and Style Finds.",
       "Each one helps intori understand what you like, what you avoid, and what actually fits your life."
     ]
   },
   {
     question: "Do I need to write prompts?",
     answer: [
-      "No. intori is built for people who want useful AI-assisted output without having to figure out what to ask.",
+      "No. intori is built for people who want useful answers without having to figure out what to ask.",
       "You answer quick questions, and intori turns that into a useful starting point."
     ]
   },
   {
     question: "What can intori do right now?",
     answer: [
-      "Four daily helpers are live: Today's Food, Game Day, live-music ideas, and Style Finds.",
+      "Five daily helpers are live: Today's Food, Watch Radar, Game Day, Music Events, and Style Finds.",
       "Each gives you a useful first pass that fits your taste, timing, and constraints, and you can go deeper in a quick chat inside intori whenever you want more."
     ]
   },
   {
-    question: "How is intori different from ChatGPT, Claude, or Gemini?",
+    question: "What makes intori different?",
     answer: [
-      "General AI tools start you at a blank box and wait for you to explain what you want.",
-      "intori already remembers what matters to you and does the first pass for you, so you get useful food picks, game-day plans, live-music ideas, and style finds without setting the scene every time. When you want more, you go deeper in a quick chat right inside intori."
+      "Most tools start you at a blank box and wait for you to explain what you want.",
+      "intori already remembers what matters to you and does the first pass for you, so you get dinner picks, watch-night ideas, game-day plans, live shows, and style finds without setting the scene every time. When you want more, you go deeper in a quick chat right inside intori."
     ]
   },
   {

--- a/lib/seo.tsx
+++ b/lib/seo.tsx
@@ -4,7 +4,7 @@ export const SITE_URL = 'https://www.intori.co'
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/og/og-default.jpg`
 export const DEFAULT_TITLE = 'intori - Made for you. Within minutes.'
 export const DEFAULT_DESCRIPTION =
-  'Choose where to start, answer a few quick questions, and intori shapes personalized food picks, game-day plans, live-music ideas, and style finds around you.'
+  'Choose where to start, answer a few quick questions, and intori shapes personalized food picks, what to watch, game-day plans, live shows, and style finds around you.'
 export const DEFAULT_SOCIAL_DESCRIPTION =
   'Choose where to start, answer quick questions, and intori gives you a more personal starting point.'
 

--- a/lib/seo.tsx
+++ b/lib/seo.tsx
@@ -4,7 +4,7 @@ export const SITE_URL = 'https://www.intori.co'
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/og/og-default.jpg`
 export const DEFAULT_TITLE = 'intori - Made for you. Within minutes.'
 export const DEFAULT_DESCRIPTION =
-  'Choose where to start, answer a few quick questions, and intori shapes personalized food picks, what to watch, game-day plans, live shows, and style finds around you.'
+  'Choose where to start, answer a few quick questions, and intori shapes food picks, what to watch, game-day plans, live shows, and style finds around you.'
 export const DEFAULT_SOCIAL_DESCRIPTION =
   'Choose where to start, answer quick questions, and intori gives you a more personal starting point.'
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,7 +30,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width, viewport-fit=cover"
         />
-        <meta name="keywords" content="intori, World, personalization, food ideas, game day, live music, style finds"/>
+        <meta name="keywords" content="intori, personalization, food ideas, what to watch, game day, live music events, style finds"/>
         <meta name="author" content="Tuum Tech"/>
       </Head>
       <SeoHead canonicalPath="/" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -191,7 +191,7 @@ export default function HomePage() {
                     Dinner,<br />decided.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer a few quick questions and intori hands you three dinner picks for tonight, shaped by your household&rsquo;s tastes, in about 30 seconds. What to watch, game day, live music, and style come next, each learning as you go.
+                    Answer a few quick questions and intori hands you three dinner picks for tonight in about 30 seconds, shaped by your household&rsquo;s tastes. What to watch, game day, live music, and style come next, each learning as you go.
                   </p>
                   <div className={styles.heroCtas}>
                     <a

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,7 @@ const HOW_STEPS = [
   {
     number: "1",
     title: "Choose where to start.",
-    body: "Start with food, game day, live music, or style, the daily helpers intori personalizes for you.",
+    body: "Start with food, what to watch, game day, live music, or style, the daily helpers intori personalizes for you.",
     visual: "packs",
   },
   {
@@ -84,7 +84,7 @@ const HOW_STEPS = [
   {
     number: "3",
     title: "Get picks made for you.",
-    body: "Run intori for food picks, game-day plans, live-music ideas, and style finds, then see more in a quick chat inside intori.",
+    body: "Run intori for food picks, watch-night ideas, game-day plans, live shows, and style finds, then see more in a quick chat inside intori.",
     visual: "tools",
   },
 ]
@@ -191,7 +191,7 @@ export default function HomePage() {
                     Dinner,<br />decided.
                   </h1>
                   <p className={styles.heroBody}>
-                    Answer a few quick questions and intori hands you three dinner picks for tonight &mdash; shaped by your household&rsquo;s tastes, in about 30 seconds. Game day, live music, and style come next, each learning as you go.
+                    Answer a few quick questions and intori hands you three dinner picks for tonight, shaped by your household&rsquo;s tastes, in about 30 seconds. What to watch, game day, live music, and style come next, each learning as you go.
                   </p>
                   <div className={styles.heroCtas}>
                     <a
@@ -246,8 +246,8 @@ export default function HomePage() {
                         </svg>
                       </span>
                       <div className={styles.floatText}>
-                        <p className={styles.floatCardLabel}>Music</p>
-                        <p className={styles.floatCardTitle}>Better music picks for you</p>
+                        <p className={styles.floatCardLabel}>Music Events</p>
+                        <p className={styles.floatCardTitle}>See who&rsquo;s playing near you</p>
                       </div>
                     </div>
 


### PR DESCRIPTION
Part of the pre-pivot residue audit (website copy tier). Copy/frontmatter only.

- Hero body em dash removed; hero, how-it-works, FAQ, default meta description, and global keywords now cover all five helpers (Watch Radar was missing everywhere; the FAQ literally said "Four daily helpers are live").
- Music framing moves to live events: float card says "See who's playing near you" under a "Music Events" label.
- FAQ de-AI'd: the ChatGPT/Claude/Gemini comparison question is reframed outcome-first as "What makes intori different?", "asking AI myself" and "AI-assisted output" phrasing removed.
- `packs-build-your-identity.md` and `introducing-scis.md` set `published: false` with provenance comments (same treatment as `intori-now-live-on-world.md`). They were live and their Packs/Stamps/matches deks rendered as page meta/og descriptions; `lib/news.ts` already filters unpublished from index, routes, and sitemap.

Verified: `tsc --noEmit` clean, `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)