### PR TITLE
legal: cover the iOS app, dietary data, and subscriptions

### DIFF
--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import Link from 'next/link'
 import { LegalLayout } from '../layouts/Legal'
 import { SeoHead } from '@/lib/seo'
 
@@ -14,7 +15,16 @@ const Privacy: NextPage = () => {
 
       <LegalLayout>
         <h1>intori Privacy Policy</h1>
-        <p><strong>Last Updated: June 26, 2026</strong></p>
+        <p><strong>Last Updated: August 11, 2026</strong></p>
+
+      <p>
+        This policy covers the intori website and the intori mobile app. There is one policy for both.
+      </p>
+
+      <h2>What changed in this update</h2>
+      <p>
+        This update covers the intori mobile app for iPhone. It describes the dietary and health-adjacent information you declare and how we use it. It names every AI processor and data provider that receives context from intori, not just OpenAI. It adds subscription and billing information. It also replaces the old note that export and deletion tools were still being built, because you can now delete your account from inside the app.
+      </p>
 
       <h2>Who we are</h2>
       <p>
@@ -30,15 +40,28 @@ const Privacy: NextPage = () => {
 
       <h2>What intori is</h2>
       <p>
-        intori helps you build and use a personal preference and context profile. Depending on the features you use, intori may help you answer questions, unlock topics, manage local context, earn or use credits, receive AI-assisted helper results, discover recommended matches, and share scoped context with connected apps you approve.
+        intori is a household personalization service. You declare preferences and constraints for your household, and intori uses those declared signals to produce daily suggestions with sources attached: what to cook or eat, what to watch, live music and events, and sports. The features that produce those suggestions are called helpers.
+      </p>
+      <p>How your declarations are used:</p>
+      <ul>
+        <li>What you declare can bind a hard filter. A declared constraint can remove results.</li>
+        <li>What intori infers from your activity can only change the order of results. It cannot remove a result or add one back.</li>
+        <li>Safety-class items fail closed. If the information available to intori does not show that an item meets a declared safety constraint, intori leaves it out rather than guess.</li>
+        <li>intori shows you which declared constraints it applied to a result, so you can correct anything that looks wrong.</li>
+      </ul>
+      <p>
+        intori applies what you declared to what its sources say. It is not a verification or certification service, and it does not independently confirm that a source is correct. Please read the dietary, allergen, and safety section of our <Link href="/terms-of-use">Terms of Use</Link> before relying on a suggestion for a food allergy or a medical dietary need.
       </p>
       <p>
-        intori is being built around user-owned data and user-controlled consent. Your answers, preferences, local context, and personal signals are yours. We use them to provide the services you ask for, personalize your experience, and help you control where your context is used.
+        intori is built around user-owned data and user-controlled consent. Your answers, preferences, declared constraints, local context, and personal signals are yours. We use them to provide the services you ask for, personalize your experience, and help you control where your context is used.
       </p>
 
       <h2>Eligibility</h2>
       <p>
         intori is not directed to children under 13. You must be at least 13 years old to use intori. If the law where you live requires a higher age to consent to the processing of your personal data, you must be old enough to provide that consent or use intori only with valid permission from a parent or legal guardian. If we learn that we collected personal information from a child under 13, we will take steps to delete it.
+      </p>
+      <p>
+        Children in your household are treated differently from children who use intori. A parent or guardian may declare a dietary constraint that applies to a child in the household, for example a nut allergy. intori does not collect the child&apos;s name, age, birthdate, photo, or any other direct identifier. The constraint is stored as an unnamed household constraint. There is no profile for that child and no account for that child. See &quot;Dietary constraints and health-adjacent information&quot; below.
       </p>
 
       <h2>Information we collect</h2>
@@ -52,24 +75,49 @@ const Privacy: NextPage = () => {
       </p>
       <ul>
         <li>Your email address, when you sign in on the web using a one-time email magic link.</li>
+        <li>Sign in with Apple identifiers, including the user identifier Apple gives us and the email address Apple passes along, which may be a private relay address if you chose to hide your email.</li>
         <li>World App, World Mini App, World ID, or wallet-based identifiers, such as wallet address, username, profile image, authentication messages, signatures, nonce records, and verification results.</li>
-        <li>Apple sign-in identifiers, where Apple sign-in is available.</li>
         <li>Farcaster account identifiers, such as FID, username, display name, profile image, bio, and related public profile data.</li>
-        <li>Account-linking records that connect the sign-in methods you use into a single intori account, so your credits, runs, and personalization stay unified across the web and supported platforms.</li>
+        <li>Account-linking records that connect the sign-in methods you use into a single intori account, so your subscription, runs, and personalization stay unified across the web, the app, and supported platforms.</li>
         <li>Session tokens and cookies used to keep you signed in.</li>
         <li>Information about the client app or platform through which you accessed intori.</li>
       </ul>
 
       <h3>Answers, preferences, and context</h3>
       <p>
-        When you answer questions, complete onboarding, use credits, rate insights, or interact with helper surfaces, we collect the information you choose to provide. This may include:
+        When you answer questions, complete onboarding, declare constraints, rate results, or interact with helper surfaces, we collect the information you choose to provide. This may include:
       </p>
       <ul>
         <li>Answers to questions about preferences, tastes, interests, values, activities, identity, and context.</li>
-        <li>Topics, groups, credit history, streaks, and other progress within intori.</li>
+        <li>Declared household constraints, including the dietary constraints described below.</li>
+        <li>Topics, groups, streaks, and other progress within intori.</li>
         <li>Feedback, ratings, likes, skips, and other interaction signals.</li>
         <li>Public share data when you choose to create or distribute share links or share images.</li>
       </ul>
+
+      <h3>Dietary constraints and health-adjacent information</h3>
+      <p>
+        You can declare dietary constraints for your household. You type or select these yourself. We do not buy them, infer them from medical records, or read them from Apple Health or any other health app. Declared dietary constraints may include:
+      </p>
+      <ul>
+        <li>Allergies and intolerances, such as peanuts, shellfish, or lactose.</li>
+        <li>Medical dietary needs, such as celiac disease, diabetes, or a low-sodium diet.</li>
+        <li>Faith-based dietary practice, such as halal, kosher, or a fasting period.</li>
+        <li>Dietary choices, such as vegetarian, vegan, or pescatarian.</li>
+        <li>Dislikes and ingredients you would rather avoid for reasons that are not health related.</li>
+      </ul>
+      <p>
+        Some of this is health information. Apple&apos;s App Privacy framework treats user-provided health or medical data as Health data, and we treat declared dietary constraints that way too.
+      </p>
+      <p>
+        We use declared dietary constraints to filter and rank what intori suggests, to explain why a suggestion was included or left out, and to decide what to ask you next. We do not use them for advertising. We do not sell them. We do not show them to other intori users.
+      </p>
+      <p>
+        We store the constraint and whether it applies to you or to someone else in your household. We do not store the names, ages, birthdates, photos, relationships, or any other identifying details of the people in your household. A constraint is recorded as something like &quot;severe peanut allergy, applies to a household member&quot;, not as a profile of that person. intori does not have household member profiles.
+      </p>
+      <p>
+        You can view, correct, and delete your declared dietary constraints at any time in intori. Deleting a constraint stops intori from applying it to future suggestions.
+      </p>
 
       <h3>Local context</h3>
       <p>
@@ -78,7 +126,7 @@ const Privacy: NextPage = () => {
 
       <h3>Derived and inferred data</h3>
       <p>
-        intori may create derived data from your activity, such as topic signals, sensitivity tiers, visibility states, match context, vibe summaries, chemistry summaries, helper context summaries, and personalization profiles. These derived records help intori decide what questions to ask, what context to include, what to exclude, and what experiences may be relevant to you.
+        intori may create derived data from your activity, such as topic signals, sensitivity tiers, visibility states, match context, vibe summaries, chemistry summaries, helper context summaries, and personalization profiles. These derived records help intori decide what questions to ask, what context to include, what to exclude, and what may be relevant to you. Inferred data can change the order of your results. It cannot bind a hard filter, and it cannot override something you declared.
       </p>
 
       <h3>Consent and connected app records</h3>
@@ -91,17 +139,20 @@ const Privacy: NextPage = () => {
         When you use AI-assisted features, we may process selected intori context, local context when active, source-search results, your displayed request, generated output, result receipts, feedback, model name, prompt version or hash, token estimates, cost estimates, duration, errors, and related metadata.
       </p>
       <p>
-        We use AI service providers, including OpenAI, to generate or support some results. AI outputs may be incomplete, outdated, or inaccurate, and should be checked before you rely on them.
+        AI outputs may be incomplete, outdated, or inaccurate, and should be checked before you rely on them.
       </p>
 
-      <h3>Payments and credits</h3>
+      <h3>Payments and subscriptions</h3>
       <p>
-        If you buy or activate paid credits, helper access, or similar features, we may store purchase reference, provider, token symbol, token amount, transaction ID, transaction hash, status, failure codes, failure reasons, confirmation time, activation time, and verification metadata. Payments may be processed through third-party card payment processors such as Stripe, third-party wallets, World Pay, blockchain networks, or other supported payment rails. Card payments are handled by the processor; we do not store full payment card numbers, and we do not collect your private keys.
+        If you subscribe to intori, we store subscription records such as plan, status, trial status, start date, renewal date, cancellation date, purchase reference, provider, transaction identifier, and receipt validation results. If you subscribe in the iOS app, Apple processes the payment and gives us a receipt and a subscription status. We do not receive your payment card number from Apple. If you subscribe on the web, Stripe processes the payment. Stripe handles your card details, and we store a customer reference, the card brand and last four digits where Stripe provides them, and the status of the payment. We do not store full payment card numbers.
+      </p>
+      <p>
+        If you previously bought credits, we may keep the related purchase records, including provider, amount, transaction identifier, status, failure codes, confirmation time, and verification metadata, for accounting, fraud prevention, and dispute purposes. Credit purchases made through a wallet or a blockchain network on the World App and Farcaster surfaces may include a transaction hash and may be public on that network. Those payment methods are not part of the iOS app. We do not collect your private keys.
       </p>
 
       <h3>Notifications</h3>
       <p>
-        If you enable notifications, we may store notification tokens, notification URLs, opt-in status, notification campaign information, send logs, and delivery or failure metadata. You can opt out through the applicable platform or intori notification controls where available.
+        If you enable notifications, we may store notification tokens, notification URLs, opt-in status, notification campaign information, send logs, and delivery or failure metadata. You can opt out through the applicable platform or intori notification controls. See the mobile app section below for how this works on iOS.
       </p>
 
       <h3>Usage, safety, and support information</h3>
@@ -116,14 +167,44 @@ const Privacy: NextPage = () => {
       <ul>
         <li>Your legal name.</li>
         <li>Your mobile or other phone number.</li>
+        <li>The names, ages, birthdates, or identities of the people in your household.</li>
+        <li>Medical records, clinical diagnoses, prescriptions, or data from Apple Health or any other health app.</li>
         <li>Government ID numbers, KYC documents, or biometric identifiers.</li>
         <li>Private keys, recovery phrases, or wallet seed phrases.</li>
         <li>Payment card numbers or bank account numbers.</li>
         <li>Precise GPS coordinates, raw coordinates, or inferred home or work location.</li>
-        <li>Your device address book or phone contacts.</li>
+        <li>Your device address book, phone contacts, photos, calendar, or microphone.</li>
       </ul>
       <p>
-        Third-party platforms you use with intori, such as Farcaster, World App, wallets, payment providers, or blockchain networks, may collect information under their own policies.
+        Third-party platforms you use with intori, such as Apple, Farcaster, World App, wallets, payment providers, or blockchain networks, may collect information under their own policies.
+      </p>
+
+      <h2>The intori mobile app</h2>
+      <p>
+        The intori app for iPhone works the same way as the website, and this policy applies to both. A few things are specific to the app.
+      </p>
+
+      <h3>Push notifications</h3>
+      <p>
+        If you allow notifications, we store a device push token so we can send the reminders and daily suggestions you asked for, along with your opt-in status, send logs, and delivery or failure information. Notifications are delivered through Apple Push Notification service. You can turn notifications off at any time in the iOS Settings app, under Notifications, and in intori wherever the app offers a notification control. Turning them off in iOS stops delivery.
+      </p>
+
+      <h3>Approximate location</h3>
+      <p>
+        The app may ask permission to use your approximate location. If you allow it, we use it to fill in your local context, so helpers can suggest nearby restaurants, venues, and events. The app asks for approximate location, not precise location. We do not track you in the background, we do not build a location history, and we do not infer your home or work address. You can deny the request and type a city instead, and you can change the permission later in the iOS Settings app. The app works either way.
+      </p>
+
+      <h3>Device and diagnostic information</h3>
+      <p>
+        The app collects device model, operating system version, app version, language and region, and crash and performance diagnostics. We use this to keep the app working and to fix problems, and it may be linked to your account for support and abuse prevention.
+      </p>
+      <p>
+        intori collects all of this itself and writes it to our own records. The app contains no third-party analytics, crash reporting, attribution, or advertising software development kits. Nothing about your use of the app is sent to an analytics company. The app does not use the device advertising identifier and does not track you across other companies&apos; apps or websites. If we ever add a third-party diagnostics tool, we will update this policy and the App Store privacy label before it ships.
+      </p>
+
+      <h3>Deleting your account in the app</h3>
+      <p>
+        You can delete your intori account from inside the app. See &quot;Your controls and choices&quot; below.
       </p>
 
       <h2>How we use information</h2>
@@ -131,10 +212,12 @@ const Privacy: NextPage = () => {
       <ul>
         <li>Provide, maintain, personalize, and improve intori.</li>
         <li>Authenticate users and maintain sessions.</li>
-        <li>Build and update your preferences, groups, credits, answers, local context, and personalization state.</li>
-        <li>Generate recommendations, helper results, match suggestions, and context summaries.</li>
-        <li>Let you control topic, group, local context, notification, and connected app consent.</li>
-        <li>Verify paid credit or helper access transactions.</li>
+        <li>Build and update your preferences, declared constraints, groups, answers, local context, and personalization state.</li>
+        <li>Apply your declared constraints as filters, use inferred signals only to change ranking, and show you which constraints were applied to a result.</li>
+        <li>Generate suggestions, helper results, match suggestions, and context summaries.</li>
+        <li>Decide what to ask you next.</li>
+        <li>Let you control topic, group, local context, notification, AI sharing, and connected app consent.</li>
+        <li>Process subscriptions, verify purchases, and manage trials, renewals, and cancellations.</li>
         <li>Show limited recommended match and approved friend information.</li>
         <li>Send notifications you request or allow.</li>
         <li>Detect, prevent, and respond to spam, abuse, fraud, security incidents, and violations of our terms.</li>
@@ -149,9 +232,39 @@ const Privacy: NextPage = () => {
       <h2>How information is shared</h2>
       <p>We share information only as described below.</p>
 
+      <h3>With AI processors</h3>
+      <p>
+        Two of the companies we work with are AI processors. To produce a helper result, intori sends them a limited amount of context. We send what the request needs and no more. We do not send your email address, sign-in identifiers, or payment information to them.
+      </p>
+      <ul>
+        <li><strong>OpenAI.</strong> Used to interpret your request, summarize sources, and write the result. May receive your request text, the declared preferences and dietary constraints relevant to that request, coarse local context, and source material retrieved for the request.</li>
+        <li><strong>Perplexity.</strong> Used for search and retrieval when a helper needs current information. May receive a search query built from your request and the relevant declared preferences, which can include dietary constraints.</li>
+      </ul>
+      <p>
+        These processors receive context in order to answer a request. They do not receive your intori account. We reach both companies through their developer APIs, not through their consumer products. We send them context to answer your request. We do not send it for model training, and we do not ask them to train on it. What each company does with data it receives through its API is governed by that company&apos;s own terms. If our use changes, we will update this policy first.
+      </p>
+
+      <h3>With data providers</h3>
+      <p>
+        The following are data APIs, not AI services. intori queries them for facts and listings. They do not generate results, and they do not receive your intori account.
+      </p>
+      <ul>
+        <li><strong>Spoonacular.</strong> Used for recipe and ingredient data. May receive recipe search terms, including dietary constraints and excluded ingredients such as allergens.</li>
+        <li><strong>Google Places.</strong> Used to find and describe local venues such as restaurants. May receive coarse local context, such as a city and a search radius, and venue search terms.</li>
+        <li><strong>Ticketmaster.</strong> Used for live event and ticket listings. May receive coarse local context, date ranges, and event search terms such as a genre or an artist.</li>
+      </ul>
+
+      <h3>Your permission before context goes to an AI processor</h3>
+      <p>
+        We ask for your permission before intori sends your personal context to OpenAI or Perplexity. The first time you use a feature that needs one of them, intori explains what will be sent and asks you to agree. You can decline. If you decline, that feature will not run, and the rest of intori keeps working.
+      </p>
+      <p>
+        You can see and change that permission at any time in Everything we hold, on the You tab, or by emailing <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>. Withdrawing permission stops future sharing. It cannot undo sharing that already happened.
+      </p>
+
       <h3>With other intori users</h3>
       <p>
-        intori is not designed to broadly expose your answers or personal context to other users. Recommended matches who are not approved friends may see only limited profile information, such as avatar, username, vibe, and mutual friends. If both people approve the connection, approved friends may also see a chemistry summary and groups in common.
+        intori is not designed to broadly expose your answers or personal context to other users. Your declared dietary constraints are never shown to other users. Recommended matches who are not approved friends may see only limited profile information, such as avatar, username, vibe, and mutual friends. If both people approve the connection, approved friends may also see a chemistry summary and groups in common.
       </p>
       <p>
         Users who can see information may save or reshare it outside intori, so you should not share information that you do not want others to see.
@@ -162,7 +275,7 @@ const Privacy: NextPage = () => {
         If you approve a connected app, intori may share a scoped context bundle with that app. For example, a music scene scope may include music preference summaries, independent-artist openness or support style, coarse active local context, and missing areas that help the app ask useful follow-up questions.
       </p>
       <p>
-        The current connected app design excludes raw answers, raw questions, exact location, GPS coordinates, inferred home or work location, payment data, wallet claims, KYC claims, biometric claims, and identity claims unless a future feature clearly asks for additional consent. You can revoke connected app access where the product provides revocation controls.
+        The current connected app design excludes raw answers, raw questions, declared dietary and health-adjacent constraints, exact location, GPS coordinates, inferred home or work location, payment data, wallet claims, KYC claims, biometric claims, and identity claims unless a future feature clearly asks for additional consent. You can revoke connected app access where the product provides revocation controls.
       </p>
       <p>
         Once a connected app receives information, that app&apos;s own terms and privacy policy may apply to its handling of the information.
@@ -170,15 +283,15 @@ const Privacy: NextPage = () => {
 
       <h3>With service providers</h3>
       <p>
-        We use service providers to host and operate intori, store data, process payments or payment verification, deliver notifications, provide AI functionality, support analytics and aggregate reporting, secure intori, and provide customer support. These providers may process information only as needed to perform services for us, subject to appropriate contractual and security obligations.
+        We use service providers to host and operate intori, store data, process payments, deliver notifications, provide AI processing and source data, secure intori, and provide customer support. These providers may process information only as needed to perform services for us, subject to appropriate contractual and security obligations.
       </p>
       <p>
-        Service providers may include cloud hosting and database providers, Farcaster and Farcaster data providers, World App and Worldcoin services, wallet or blockchain infrastructure providers, payment verification providers, AI providers such as OpenAI, notification providers, analytics providers, and support tools.
+        Service providers include cloud hosting and database providers, Apple for app distribution, sign-in, push notifications, and App Store billing, Stripe for web payments, OpenAI and Perplexity for AI processing, Spoonacular, Google Places, and Ticketmaster for recipe, venue, and event data, Farcaster and Farcaster data providers, World App and Worldcoin services, wallet or blockchain infrastructure providers, and support tools.
       </p>
 
       <h3>With third-party platforms</h3>
       <p>
-        When you use intori through Farcaster, World App, wallets, blockchain networks, or other third-party platforms, those platforms may process information under their own terms and privacy policies. Blockchain transactions may be public and difficult or impossible to delete.
+        When you use intori through Apple, Farcaster, World App, wallets, blockchain networks, or other third-party platforms, those platforms may process information under their own terms and privacy policies. Blockchain transactions may be public and difficult or impossible to delete.
       </p>
 
       <h3>For legal, safety, and business reasons</h3>
@@ -188,24 +301,40 @@ const Privacy: NextPage = () => {
 
       <h2>Selling or sharing for advertising</h2>
       <p>
-        We do not sell or rent your personal information. We do not currently share personal information for cross-context behavioral advertising. If this changes, we will update this policy and provide any required choices.
+        We do not sell or rent your personal information. We do not share personal information for cross-context behavioral advertising. We do not sell, rent, or share your declared dietary and health-adjacent information for any advertising purpose, and we do not use it to target ads to you. If any of this changes, we will update this policy and provide any required choices.
       </p>
 
       <h2>Your controls and choices</h2>
       <p>
-        intori is designed to give you increasing control over your data and consent. Depending on the feature, you may be able to:
+        intori is designed to give you control over your data and your consent. Depending on the feature, you can:
       </p>
       <ul>
         <li>Skip questions or choose what answers to provide.</li>
+        <li>View, correct, or delete a declared dietary or household constraint.</li>
         <li>Pause, edit, or delete local context.</li>
         <li>Grant or revoke topic or group consent.</li>
+        <li>Grant or withdraw permission for intori to send your context to an AI processor.</li>
+        <li>Clear what intori has learned about you, or delete your account, from the You tab.</li>
         <li>Approve or revoke connected app grants.</li>
-        <li>Enable or disable notifications through platform or intori controls.</li>
+        <li>Enable or disable notifications through the iOS Settings app or intori notification controls.</li>
         <li>Choose whether to create or distribute share links and share images.</li>
         <li>Contact us to request access, correction, export, deletion, or other privacy rights.</li>
       </ul>
+
+      <h3>Deleting your account</h3>
       <p>
-        Self-service export and deletion tools are still being developed. Until those tools are available, contact <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>.
+        You can delete your intori account yourself. In the app, open the You tab and choose Delete your account. You can also reach it from Everything we hold. On the web, email <a href="mailto:contact@tuum.tech">contact@tuum.tech</a> and we will delete the account.
+      </p>
+      <p>
+        Deleting your account removes your answers, declared preferences, declared dietary constraints, local context, helper results, and connected app grants, except for records we must keep for legal, accounting, security, or fraud-prevention reasons. If you signed in with Apple, deleting your account also revokes the Sign in with Apple token, so intori no longer holds an active sign-in relationship with your Apple ID.
+      </p>
+      <p>
+        Deletion is permanent. We cannot restore a deleted account. Deleting your intori account does not cancel an App Store subscription. Cancel that separately in your Apple account subscription settings.
+      </p>
+
+      <h3>Getting a copy of your data</h3>
+      <p>
+        A self-service export tool is not available yet. To get a copy of your data, email <a href="mailto:contact@tuum.tech">contact@tuum.tech</a> and we will send you an export.
       </p>
 
       <h2>Retention</h2>
@@ -213,7 +342,7 @@ const Privacy: NextPage = () => {
         We keep information for as long as needed to provide intori, maintain user controls and receipts, prevent abuse, comply with legal obligations, resolve disputes, and enforce agreements.
       </p>
       <p>
-        Session cookies are intended to expire after a limited period. Partner grants may expire or be revoked. Payment and transaction records may be retained for accounting, fraud prevention, charge dispute, tax, and legal reasons. Some profile, answer, consent, AI result, receipt, and derived records may remain until you delete them, revoke the relevant consent where supported, or request deletion.
+        Session cookies are intended to expire after a limited period. Partner grants may expire or be revoked. Payment, subscription, and transaction records may be retained for accounting, fraud prevention, charge dispute, tax, and legal reasons. Profile, answer, declared constraint, consent, AI result, receipt, and derived records are kept until you delete them, revoke the relevant consent where supported, delete your account, or request deletion.
       </p>
       <p>
         We are continuing to define more specific retention periods for each data category.
@@ -221,7 +350,7 @@ const Privacy: NextPage = () => {
 
       <h2>Security</h2>
       <p>
-        We use reasonable administrative, technical, and organizational safeguards designed to protect information. No online service can guarantee absolute security. You are responsible for keeping your wallet, platform account, device, and any authentication credentials secure.
+        We use reasonable administrative, technical, and organizational safeguards designed to protect information. No online service can guarantee absolute security. You are responsible for keeping your device, platform account, and any authentication credentials secure.
       </p>
 
       <h2>International processing</h2>
@@ -231,7 +360,7 @@ const Privacy: NextPage = () => {
 
       <h2>Privacy rights</h2>
       <p>
-        Depending on where you live, you may have rights to request access, correction, deletion, portability, restriction, objection, or information about how your personal information is used and disclosed. You may also have rights to opt out of certain sales, sharing, targeted advertising, or sensitive-data uses. We do not currently sell personal information or share it for cross-context behavioral advertising.
+        Depending on where you live, you may have rights to request access, correction, deletion, portability, restriction, objection, or information about how your personal information is used and disclosed. You may also have rights to limit the use of sensitive personal information, or to opt out of certain sales, sharing, or targeted advertising. Declared dietary and health-adjacent information is treated as sensitive. We use it only to provide intori, and we do not sell it or share it for advertising.
       </p>
       <p>
         To make a privacy request, contact <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>. We may need to verify your identity before fulfilling a request. We will not discriminate against you for exercising privacy rights.

--- a/pages/terms-of-use.tsx
+++ b/pages/terms-of-use.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+import Link from 'next/link'
 import { LegalLayout } from '../layouts/Legal'
 import { SeoHead } from '@/lib/seo'
 
@@ -14,10 +15,19 @@ const Terms: NextPage = () => {
 
       <LegalLayout>
         <h1>intori Terms of Use</h1>
-        <p><strong>Last Updated: June 26, 2026</strong></p>
+        <p><strong>Last Updated: August 11, 2026</strong></p>
 
       <p>
-        These Terms of Use (&quot;Terms&quot;) are an agreement between you and Tuum Technologies, Inc. (&quot;Tuum&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) and govern your access to and use of intori, including the intori website, mini app experiences, personal preference and context profile, credits, helper results, connected app flows, APIs, and related services (together, the &quot;Services&quot;).
+        These terms cover the intori website and the intori mobile app. There is one set of terms for both.
+      </p>
+
+      <h2>What changed in this update</h2>
+      <p>
+        This update covers the intori mobile app for iPhone. It adds a dietary, allergen, and safety section that explains what intori does and does not promise about food. It adds subscription and auto-renewal terms, including price, billing period, and how to cancel. It retires credit packs as something you can buy and explains what happens to any balance you still hold. It notes that Apple&apos;s standard app license also applies if you got the app from the App Store. The AI processors and data providers we use are named in our <Link href="/privacy-policy">Privacy Policy</Link>.
+      </p>
+
+      <p>
+        These Terms of Use (&quot;Terms&quot;) are an agreement between you and Tuum Technologies, Inc. (&quot;Tuum&quot;, &quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) and govern your access to and use of intori, including the intori website, the intori mobile app, mini app experiences, your household preference and context profile, helper results, subscriptions, connected app flows, APIs, and related services (together, the &quot;Services&quot;).
       </p>
       <p>
         By using the Services, you agree to these Terms. If you do not agree, do not use the Services.
@@ -28,12 +38,22 @@ const Terms: NextPage = () => {
         You must be at least 13 years old to use the Services. If the law where you live requires a higher age to consent to online services or personal data processing, you must be old enough to provide that consent or use the Services only with valid permission from a parent or legal guardian.
       </p>
       <p>
-        If you use the Services on behalf of another person or organization, you represent that you have authority to accept these Terms on their behalf.
+        If you use the Services on behalf of another person or organization, you represent that you have authority to accept these Terms on their behalf. If you declare a constraint that applies to someone else in your household, you represent that you are allowed to do so.
       </p>
 
       <h2>2. What intori does</h2>
       <p>
-        intori helps you build and use a personal preference and context profile. Depending on the features you use, intori may help you answer questions, unlock topics, manage local context, receive AI-assisted helper results, discover recommended matches, use credits, and share scoped context with connected apps you approve.
+        intori is a household personalization service. You declare preferences and constraints for your household. intori uses those declared signals to produce daily suggestions with sources attached: what to cook or eat, what to watch, live music and events, and sports. The features that produce those suggestions are called helpers.
+      </p>
+      <p>How your declarations are used:</p>
+      <ul>
+        <li>What you declare can bind a hard filter. A declared constraint can remove results.</li>
+        <li>What intori infers from your activity can only change the order of results. It cannot remove a result or add one back.</li>
+        <li>Safety-class items fail closed. If the information available to intori does not show that an item meets a declared safety constraint, intori leaves it out rather than guess.</li>
+        <li>intori shows you which declared constraints it applied to a result, so you can correct anything that is wrong.</li>
+      </ul>
+      <p>
+        intori applies what you declared to what its sources say. It is not a verification or certification service, and it does not independently confirm that a source is correct. Section 9 explains what this means for allergies and medical dietary needs.
       </p>
       <p>
         intori is designed around user-owned data and user-controlled consent. You decide what to provide and, where controls are available, what to share, pause, revoke, or delete.
@@ -41,18 +61,21 @@ const Terms: NextPage = () => {
 
       <h2>3. Accounts, wallets, and platform access</h2>
       <p>
-        You may access the Services on the web at app.intori.co or through supported platforms and wallets. Supported sign-in methods include email sign-in (a one-time magic link), World App or World ID, Apple sign-in where available, and other supported methods. Where you sign in through more than one method, intori may link those identities to a single intori account so your data stays unified.
+        You may access the Services on the web at app.intori.co, in the intori mobile app, or through supported platforms and wallets. Supported sign-in methods include email sign-in (a one-time magic link), Sign in with Apple, World App or World ID, and other supported methods. Where you sign in through more than one method, intori may link those identities to a single intori account so your data stays unified.
       </p>
       <p>
-        You are responsible for maintaining control of your wallet, platform account, device, authentication method, and private keys. We will never ask for your private keys or recovery phrase. Transactions or actions authorized through your wallet or platform account may be irreversible.
+        You are responsible for maintaining control of your device, platform account, wallet, authentication method, and private keys. We will never ask for your private keys or recovery phrase. Transactions or actions authorized through your wallet or platform account may be irreversible.
       </p>
       <p>
         You are responsible for all activity that occurs through your account or authenticated session, except to the extent caused by our breach of these Terms or applicable law.
       </p>
+      <p>
+        <strong>Apple App Store.</strong> If you got the intori app from the Apple App Store, your use of the app is also governed by Apple&apos;s standard Licensed Application End User License Agreement, which you can read at <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" rel="noreferrer">apple.com/legal/internet-services/itunes/dev/stdeula</a>. Where that agreement covers a matter and conflicts with these Terms, that agreement controls for the app.
+      </p>
 
       <h2>4. Your data and content</h2>
       <p>
-        As between you and Tuum, you retain ownership of the answers, preferences, local context, feedback, and other content you submit to intori (&quot;Your Content&quot;).
+        As between you and Tuum, you retain ownership of the answers, preferences, declared constraints, local context, feedback, and other content you submit to intori (&quot;Your Content&quot;).
       </p>
       <p>
         You grant us a limited, worldwide, non-exclusive, royalty-free license to host, store, copy, process, display, transmit, create operational or derived signals from, and otherwise use Your Content only as needed to provide, secure, personalize, support, and improve the Services; comply with your sharing and consent settings; provide connected app access you approve; and comply with law.
@@ -63,7 +86,7 @@ const Terms: NextPage = () => {
 
       <h2>5. Consent and connected apps</h2>
       <p>
-        Some Services depend on your consent. You may be asked to grant consent for topics, groups, local context, helper access, connected app sharing, or other scopes. You may also be able to revoke consent through intori controls.
+        Some Services depend on your consent. You may be asked to grant consent for topics, groups, local context, helper access, sharing context with an AI processor, connected app sharing, or other scopes. You may also revoke consent through intori controls.
       </p>
       <p>
         If you approve a connected app, intori may share a scoped context bundle with that app. Connected apps are independent services, and their own terms and privacy policies may apply after they receive information. We are not responsible for a connected app&apos;s use of information after you authorize sharing, except to the extent required by law or a written agreement with that app.
@@ -74,7 +97,7 @@ const Terms: NextPage = () => {
 
       <h2>6. Privacy</h2>
       <p>
-        Our Privacy Policy explains how we collect, use, share, and protect information. By using the Services, you acknowledge the Privacy Policy.
+        Our <Link href="/privacy-policy">Privacy Policy</Link> explains how we collect, use, share, and protect information, and it names the AI processors and data providers that receive context from intori. By using the Services, you acknowledge the Privacy Policy.
       </p>
 
       <h2>7. Acceptable use</h2>
@@ -89,7 +112,7 @@ const Terms: NextPage = () => {
         <li>Circumvent rate limits, access controls, consent gates, payment gates, or security measures.</li>
         <li>Reverse engineer the Services except where law prohibits this restriction.</li>
         <li>Use bots, scripts, or automated access in a way that harms the Services or violates posted rules.</li>
-        <li>Abuse AI, matching, sharing, notification, payment, credit, or connected app features.</li>
+        <li>Abuse AI, matching, sharing, notification, payment, subscription, or connected app features.</li>
         <li>Impersonate another person or misrepresent your affiliation with any person or entity.</li>
       </ul>
       <p>
@@ -104,40 +127,102 @@ const Terms: NextPage = () => {
         AI outputs are not legal, medical, financial, tax, investment, or other professional advice. intori does not purchase tickets, contact venues, complete transactions, or make commitments on your behalf unless a feature clearly says it does and you authorize that action.
       </p>
 
-      <h2>9. Credits, purchases, and payments</h2>
+      <h2>9. Dietary constraints, allergens, and safety</h2>
       <p>
-        intori may offer credits, helper access, subscriptions, or other paid features. Prices, payment methods, included features, limitations, and availability may be shown at the time of purchase.
+        Read this section carefully if you or anyone in your household has a food allergy, celiac disease, or another medical dietary condition.
       </p>
       <p>
-        Payments may be processed through third-party wallets, World Pay, blockchain networks, payment providers, or platform services. You authorize the applicable payment when you approve it through the supported platform or wallet.
+        When you declare a dietary constraint, intori applies it as a filter against the information available from its sources. Those sources include recipe databases, venue and menu listings, event listings, and web search. intori reports what those sources say. It does not verify what they say.
       </p>
       <p>
-        Blockchain and wallet transactions may be public, irreversible, delayed, failed, or subject to network fees. We are not responsible for third-party wallet, network, platform, or payment-provider failures.
+        intori is not a food safety service. We do not inspect kitchens, test food, audit suppliers, or observe how a dish is prepared. We cannot detect cross-contact, shared fryers, shared equipment, ingredient substitutions, recipe changes, or mislabeled products. A menu that says a dish is gluten free may be wrong. Independent testing has repeatedly found gluten in restaurant food sold as gluten free, and the same risk applies to any allergen.
       </p>
       <p>
-        Unless we state otherwise at the time of purchase or applicable law requires otherwise, purchases are final once delivered, activated, or consumed. Credits and helper access are for use within intori, have no cash value, and may not be transferred, resold, or redeemed for money unless we expressly allow it in writing.
+        We do not guarantee, certify, or ensure that any recipe, product, dish, restaurant, or venue is safe for a person with an allergy or a medical dietary condition. A suggestion from intori is a starting point, not a clearance.
       </p>
       <p>
-        You are responsible for any taxes, fees, or reporting obligations that apply to your transactions.
+        If you or someone in your household has a food allergy or a medical dietary need, you must confirm directly with the restaurant, the manufacturer, or your clinician before eating anything intori suggests. Read the label. Ask the kitchen. intori does not replace either.
+      </p>
+      <p>
+        intori shows you which declared constraints it applied to a result. That display describes what intori did with your declarations and the information it had. It is not a statement that the item is safe.
+      </p>
+      <p>
+        Nothing in the Services is medical advice, nutritional advice, or a diagnosis, and nothing in the Services should be used to treat or manage a medical condition. Talk to a qualified professional about your health. In an emergency, call your local emergency number.
       </p>
 
-      <h2>10. Recommended matches and friends</h2>
+      <h2>10. Subscriptions, purchases, and payments</h2>
       <p>
-        intori may show recommended matches. If you are not approved friends, the other person may see only limited profile information, such as avatar, username, vibe, and mutual friends. If both people approve the connection, approved friends may also see a chemistry summary and groups in common.
+        intori is sold as a subscription. One subscription covers your whole household.
+      </p>
+      <p>
+        <strong>Free trial.</strong> New accounts get a 14 day free trial with full access to intori. The trial is the same on the web and in the iOS app, and you provide a payment method when you start it. You are not charged during the trial. If you do not cancel before the trial ends, your subscription starts and the first charge is made then.
+      </p>
+      <p>
+        <strong>Founding year offer.</strong> We may offer a one-time founding year for $79. It covers 12 months and it has no free trial. It costs the same as a year of the annual plan, but it is not the annual plan. It is a single charge. It does not renew, it does not turn into a subscription, and we will not start billing you on a recurring basis when it ends. When the 12 months are up, your access drops to the limited free state described below. To keep paid access after that, you have to buy again yourself. Anything specific to that offer is shown to you before you buy.
+      </p>
+      <p>
+        <strong>Price and billing period.</strong> After the trial, intori costs $79 per year or $8.99 per month, depending on the plan you choose. Prices are in US dollars and do not include taxes, which may be added where required. The price, the billing period, and these terms are shown to you before you buy, and you must agree to them to subscribe.
+      </p>
+      <p>
+        <strong>Automatic renewal.</strong> Subscriptions renew automatically until you cancel. An annual plan renews every year. A monthly plan renews every month. At the start of each new period we charge the then-current price for your plan to the payment method on file. If we change the price, we will tell you before the change takes effect, and you will have a chance to cancel first.
+      </p>
+      <p>
+        <strong>When you are charged.</strong> If you subscribe during the free trial, the first charge is made when the trial ends. If you subscribe without a trial, the first charge is made when you buy. Renewal charges are made at the start of each new billing period. For App Store purchases, Apple charges within 24 hours before the end of the current period.
+      </p>
+      <p>
+        <strong>How to cancel.</strong> You can cancel at any time. If you subscribed in the iOS app, cancel in your Apple account subscription settings on your device. If you subscribed on the web, cancel in your intori account settings or by emailing <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>. To avoid the next charge, cancel at least 24 hours before the current period ends.
+      </p>
+      <p>
+        <strong>What cancellation does.</strong> Cancelling stops the next renewal. It does not end the period you already paid for. You keep paid access until the end of that period, and you are not charged again after that.
+      </p>
+      <p>
+        <strong>Cancelling during the free trial.</strong> If you cancel during the 14 day trial, you are not charged, and you keep trial access until the trial ends. To avoid being charged, cancel at least 24 hours before the trial ends.
+      </p>
+      <p>
+        <strong>What happens when paid access ends.</strong> When your trial or your subscription ends, your account moves to a limited free state. We do not delete your account, your declared preferences, or your declared constraints.
+      </p>
+      <p>
+        <strong>What the free state includes.</strong> Free keeps today&apos;s decision, recomputed each day, at one run per day, and one location. All of your declared constraints keep filtering on the free tier, including dietary and allergen constraints. Safety is never gated behind payment. Free does not keep your history and corrections, named people, travel locations, or the shareable card. A paid subscription remembers all of that and gives you three runs per day. The short version is that free forgets and paid remembers.
+      </p>
+      <p>
+        <strong>App Store purchases.</strong> If you subscribe in the intori iOS app, Apple bills you, and the purchase is governed by Apple&apos;s terms, including the Apple Media Services Terms and Conditions. You manage and cancel that subscription in your Apple account subscription settings. We cannot cancel or refund an App Store subscription for you. Send refund requests for App Store purchases to Apple.
+      </p>
+      <p>
+        <strong>Web purchases.</strong> If you subscribe on the intori website, Stripe processes the payment and we manage the subscription. Cancel in your intori account settings or by emailing <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>. Send refund requests for web purchases to us at the same address.
+      </p>
+      <p>
+        <strong>Refunds.</strong> Apple handles refunds for App Store purchases under its own policies. For web purchases, and except where the law gives you a refund right, fees already charged are not refundable, and cancelling stops future charges rather than refunding past ones. We may give a refund at our discretion.
+      </p>
+      <p>
+        <strong>Credits you paid for.</strong> intori used to sell credit packs. Credit packs are no longer sold, and a subscription is now the only way to buy access to intori. Credits you paid for do not expire. We will honor an unused purchased balance for as long as intori runs, and we will not revoke it on notice. We do not convert credit balances into subscription time. Purchased credits are for use within intori, have no cash value, and may not be transferred, resold, or redeemed for money unless we expressly allow it in writing.
+      </p>
+      <p>
+        <strong>Promotional and granted credits.</strong> Credits we gave you rather than sold you, including promotional, referral, and goodwill credits, are different. They may expire or end after we give you reasonable notice. They have no cash value and are not refundable.
+      </p>
+      <p>
+        <strong>Wallet and blockchain payments.</strong> On the World App and Farcaster surfaces, intori supports payment through a wallet or a blockchain network. Those transactions may be public, irreversible, delayed, failed, or subject to network fees, and we are not responsible for third-party wallet, network, platform, or payment provider failures. These payment methods are not available in the iOS app.
+      </p>
+      <p>
+        <strong>Taxes.</strong> You are responsible for any taxes, fees, or reporting obligations that apply to your purchases.
+      </p>
+
+      <h2>11. Recommended matches and friends</h2>
+      <p>
+        intori may show recommended matches. If you are not approved friends, the other person may see only limited profile information, such as avatar, username, vibe, and mutual friends. If both people approve the connection, approved friends may also see a chemistry summary and groups in common. Your declared dietary constraints are not shown to other users.
       </p>
       <p>
         You should not share information that you do not want others to see. People who can see information through intori may save or reshare it outside intori.
       </p>
 
-      <h2>11. Third-party services</h2>
+      <h2>12. Third-party services</h2>
       <p>
-        The Services may interact with or depend on third-party services, including Farcaster, World App, Worldcoin services, wallets, blockchain networks, RPC providers, payment providers, AI providers, notification providers, analytics providers, hosting providers, and connected apps.
+        The Services may interact with or depend on third-party services, including Apple, Stripe, OpenAI, Perplexity, Spoonacular, Google Places, Ticketmaster, Farcaster, World App, Worldcoin services, wallets, blockchain networks, RPC providers, notification providers, hosting providers, and connected apps.
       </p>
       <p>
-        We do not control third-party services and are not responsible for their content, policies, availability, security, or actions. Your use of third-party services may be governed by their own terms and privacy policies.
+        We do not control third-party services and are not responsible for their content, policies, availability, security, or actions. Information from a third-party source may be wrong, incomplete, or out of date. Your use of third-party services may be governed by their own terms and privacy policies.
       </p>
 
-      <h2>12. intori intellectual property</h2>
+      <h2>13. intori intellectual property</h2>
       <p>
         The Services, including software, interfaces, design, logos, trademarks, documentation, and other materials we provide, are owned by Tuum or our licensors. Subject to these Terms, we grant you a limited, non-exclusive, non-transferable, revocable license to use the Services for their intended purpose.
       </p>
@@ -145,20 +230,20 @@ const Terms: NextPage = () => {
         You may not copy, modify, distribute, sell, lease, or create derivative works from the Services except as allowed by these Terms, open-source licenses, or applicable law.
       </p>
 
-      <h2>13. Feedback</h2>
+      <h2>14. Feedback</h2>
       <p>
         If you provide feedback or suggestions, you grant us permission to use them without restriction or compensation. We will not treat feedback as confidential unless we separately agree in writing.
       </p>
 
-      <h2>14. Service changes and availability</h2>
+      <h2>15. Service changes and availability</h2>
       <p>
-        We may add, change, suspend, or discontinue features. We may also impose limits on use, storage, access, helper runs, credits, grants, or APIs. We will try to provide reasonable notice for material changes that negatively affect paid features or privacy-related controls, where practical.
+        We may add, change, suspend, or discontinue features. We may also impose limits on use, storage, access, helper runs, grants, or APIs. We will try to provide reasonable notice for material changes that negatively affect paid features or privacy-related controls, where practical.
       </p>
       <p>
         The Services may be unavailable, delayed, or interrupted from time to time.
       </p>
 
-      <h2>15. Security</h2>
+      <h2>16. Security</h2>
       <p>
         We use reasonable safeguards designed to protect the Services, but no online service is perfectly secure. You are responsible for securing your devices, wallets, platform accounts, and authentication methods.
       </p>
@@ -166,15 +251,15 @@ const Terms: NextPage = () => {
         You must promptly notify us at <a href="mailto:contact@tuum.tech">contact@tuum.tech</a> if you believe your account, wallet, session, grant credential, API key, or access has been compromised.
       </p>
 
-      <h2>16. Disclaimers</h2>
+      <h2>17. Disclaimers</h2>
       <p>
         The Services are provided &quot;as is&quot; and &quot;as available&quot;. To the fullest extent permitted by law, we disclaim all warranties, whether express, implied, statutory, or otherwise, including warranties of merchantability, fitness for a particular purpose, title, non-infringement, accuracy, availability, and security.
       </p>
       <p>
-        We do not guarantee that the Services will be uninterrupted, error-free, secure, accurate, or free from harmful components.
+        We do not guarantee that the Services will be uninterrupted, error-free, secure, accurate, or free from harmful components. We do not warrant that any suggestion, recipe, product, dish, restaurant, or venue is safe, suitable, or accurate for you. Section 9 applies to dietary constraints and allergens.
       </p>
 
-      <h2>17. Limitation of liability</h2>
+      <h2>18. Limitation of liability</h2>
       <p>
         To the fullest extent permitted by law, Tuum and its affiliates, officers, directors, employees, agents, and licensors will not be liable for indirect, incidental, special, consequential, exemplary, or punitive damages, or for lost profits, lost data, lost goodwill, or service interruption.
       </p>
@@ -182,31 +267,31 @@ const Terms: NextPage = () => {
         To the fullest extent permitted by law, our total liability for all claims related to the Services or these Terms will not exceed the greater of $100 or the amount you paid to Tuum for the Services in the six months before the event giving rise to the claim.
       </p>
       <p>
-        Some jurisdictions do not allow certain limitations of liability, so some limitations may not apply to you.
+        Nothing in these Terms limits liability that cannot be limited under applicable law, including liability for death or personal injury caused by negligence, fraud, or fraudulent misrepresentation, where the law does not allow that limitation. Some jurisdictions do not allow certain limitations of liability, so some limitations may not apply to you.
       </p>
 
-      <h2>18. Indemnity</h2>
+      <h2>19. Indemnity</h2>
       <p>
         To the fullest extent permitted by law, you agree to defend, indemnify, and hold harmless Tuum and its affiliates, officers, directors, employees, agents, and licensors from claims, damages, liabilities, losses, costs, and expenses, including reasonable attorneys&apos; fees, arising from or related to your misuse of the Services, Your Content, your violation of these Terms, or your violation of law or third-party rights.
       </p>
 
-      <h2>19. Termination</h2>
+      <h2>20. Termination</h2>
       <p>
-        You may stop using the Services at any time. You may request deletion of your account or data by contacting <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>, subject to retention needed for legal, security, fraud-prevention, accounting, or operational reasons.
+        You may stop using the Services at any time. You can delete your account from inside the intori mobile app, on the You tab, or by contacting <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>, subject to retention needed for legal, security, fraud-prevention, accounting, or operational reasons. Deleting your account does not cancel an App Store subscription. Cancel that separately in your Apple account subscription settings.
       </p>
       <p>
         We may suspend or terminate your access if we believe you violated these Terms, created risk, or used the Services unlawfully or abusively.
       </p>
       <p>
-        Sections that by their nature should survive termination will survive, including sections on your content license for retained data, privacy, payments, third-party services, intellectual property, disclaimers, limitation of liability, indemnity, dispute resolution, and general terms.
+        Sections that by their nature should survive termination will survive, including sections on your content license for retained data, privacy, dietary and safety disclaimers, payments, third-party services, intellectual property, disclaimers, limitation of liability, indemnity, dispute resolution, and general terms.
       </p>
 
-      <h2>20. Changes to these Terms</h2>
+      <h2>21. Changes to these Terms</h2>
       <p>
         We may update these Terms from time to time. If changes are material, we will provide reasonable notice, such as by updating the date above, posting notice in intori, or using another appropriate method. Your continued use of the Services after changes become effective means you accept the updated Terms.
       </p>
 
-      <h2>21. Governing law and dispute resolution</h2>
+      <h2>22. Governing law and dispute resolution</h2>
       <p>
         These Terms are governed by the laws of the State of North Carolina, without regard to conflict-of-law rules, except where applicable law requires otherwise.
       </p>
@@ -214,7 +299,7 @@ const Terms: NextPage = () => {
         Before filing a claim, you and Tuum agree to try to resolve the dispute informally by contacting the other party. Contact us at <a href="mailto:contact@tuum.tech">contact@tuum.tech</a>.
       </p>
 
-      <h2>22. General terms</h2>
+      <h2>23. General terms</h2>
       <p>
         You may not assign these Terms without our consent. We may assign these Terms as part of a merger, acquisition, financing, reorganization, sale of assets, or by operation of law.
       </p>


### PR DESCRIPTION
Updates the privacy policy and terms of use in place for the intori iOS launch. Same URLs, one document per topic covering both web and app.

## Privacy policy

- **Dietary and health-adjacent data.** New section describing declared allergens, medical dietary needs, and faith-based practice as health data under Apple's App Privacy framework. States explicitly that intori stores the constraint plus whether it applies to the account holder or a household member, and never the names, ages, or identities of household members.
- **Every third-party recipient named**, split into AI processors (OpenAI, Perplexity) and data providers (Spoonacular, Google Places, Ticketmaster).
- **Export and deletion** language updated to describe the shipped controls.
- **Mobile app section**: push notifications, approximate location, and diagnostics that are first-party only, with no third-party analytics or crash SDKs anywhere in the app.
- **Children** extended to cover a constraint declared for a child in the household, stored unnamed with no profile and no account.

## Terms of use

- **New section 9**, a dietary, allergen, and safety clause separate from the general AI disclaimer in section 8.
- **Section 10** carries subscription and auto-renewal terms: 14 day trial, $79/yr or $8.99/mo, price, billing period, renewal, cancellation, and the non-renewing founding year offer.
- **Credits retired.** Purchased balances honored indefinitely; promotional credits may expire on notice.
- **Apple's standard Licensed Application EULA** referenced for App Store installs.
- **Wallet and blockchain payments scoped** to the World App and Farcaster surfaces, excluded from iOS.

Sections 9 through 22 shift to 10 through 23. Both pointers to the dietary clause resolve to section 9.

## Verification

`tsc --noEmit`, `next lint`, and `next build` all clean. Both pages prerender static and render with no console errors.